### PR TITLE
feat(content): add 2026 multitenancy talk to talks.md

### DIFF
--- a/.spelling.txt
+++ b/.spelling.txt
@@ -32,6 +32,7 @@ Lightspeed
 linkinator
 macroservice
 meetups
+Multitenancy
 mypy
 netlify
 networkidle
@@ -46,6 +47,7 @@ Ollama
 optipng
 Papandrea
 papermod
+paravirtualization
 Parry
 peaceiris
 pkgs
@@ -63,5 +65,6 @@ SLSA
 blueconf
 Tanzu
 teardown
+trilemma
 WCAG
 Yubikey

--- a/content/talks.md
+++ b/content/talks.md
@@ -24,6 +24,31 @@ menu:
   main: {}
 ---
 
+## 2026
+
+### The Road to Multitenancy: Running Secure Multi-Tenant Workloads at Scale
+
+- Type: Talk
+- Date: 14th January 2026
+- Event:
+  [London Platform User Group (LoPUG)](https://www.meetup.com/london-platform-user-group-lopug/events/311100198)
+- Resources:
+  [Slides](https://talks.denhamparry.co.uk/2026-01-14-road-to-multitenancy.html)
+
+Platform engineers face an impossible choice when running multi-tenant
+workloads: security, performance, or scale—pick two. This talk explores the
+fundamental trade-offs in container isolation, examining six different
+approaches from separate machines to bare metal, and why each forces
+compromises. Discover how traditional solutions like Kata Containers, gVisor,
+and Firecracker sacrifice either speed or simplicity to achieve security, and
+why shared kernel approaches fail compliance requirements. Learn about the
+container runtime innovation that finally breaks the trilemma, delivering
+VM-level isolation with near-native performance through paravirtualization. The
+presentation includes a detailed comparison matrix, real-world use cases from
+SaaS platforms to GPU-accelerated AI workloads, and practical guidance for
+platform teams building secure, scalable multi-tenant systems without
+architectural compromises.
+
 ## 2025
 
 ### What I wish I knew about AI 10 days ago


### PR DESCRIPTION
## Summary

Add new 2026 talk entry for "The Road to Multitenancy: Running Secure Multi-Tenant Workloads at Scale" presented at London Platform User Group (LoPUG) on January 14, 2026.

## Changes Made

- Added 2026 section to content/talks.md
- Included comprehensive talk description covering:
  - Container isolation approaches and fundamental trade-offs
  - Traditional solutions (Kata Containers, gVisor, Firecracker)
  - VM-level isolation with near-native performance via paravirtualization
  - Practical guidance for platform teams building multi-tenant systems
- Added event and resource links (meetup page and slides)
- Updated .spelling.txt with technical terms (Multitenancy, trilemma, paravirtualization)

## Motivation

Document the latest speaking engagement for 2026, providing visitors with information about the talk topic, event details, and access to presentation materials.

## Testing

- [x] Pre-commit hooks pass (markdownlint, cspell, prettier)
- [x] Hugo build succeeds locally
- [x] Content renders correctly on the website
- [x] Links are valid and accessible
- [x] Spelling validation passes with updated dictionary

## Resources

- Event: https://www.meetup.com/london-platform-user-group-lopug/events/311100198
- Slides: https://talks.denhamparry.co.uk/2026-01-14-road-to-multitenancy.html

## Breaking Changes

None

## Related Issues

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)