### PR TITLE
docs(content): update talks.md reviewed date to 2026-02-04

### DIFF
--- a/content/talks.md
+++ b/content/talks.md
@@ -1,7 +1,7 @@
 ---
 title: Talks
 date: 2022-04-22T21:00:00+00:00
-reviewed: 2025-12-05
+reviewed: 2026-02-04
 tags: ["talk"]
 author: Lewis Denham-Parry
 showToc: true


### PR DESCRIPTION
## Summary

Updates the reviewed date metadata in talks.md from 2025-12-05 to 2026-02-04 to reflect current content review status.

## Changes Made

- Updated `reviewed` field in talks.md frontmatter from 2025-12-05 to 2026-02-04

## Motivation

Maintaining accurate reviewed dates ensures content freshness tracking and helps with content maintenance scheduling.

## Testing

- [x] Pre-commit hooks pass
- [x] Hugo build will verify in CI
- [x] No functional changes - metadata only

## Breaking Changes

None - This is a metadata-only update.

## Related Issues

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)