### PR TITLE
fix(ci): override RSS template to fix Hugo v0.157.0 build failure

### DIFF
--- a/.spelling.txt
+++ b/.spelling.txt
@@ -16,6 +16,7 @@ envrc
 Feria
 Fulcio
 gnumake
+gohugo
 googletagmanager
 Gotchas
 hidemeta
@@ -49,6 +50,8 @@ optipng
 Papandrea
 papermod
 paravirtualization
+pctx
+ShowFullTextinRSS
 Parry
 peaceiris
 pkgs

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,47 @@
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+{{- $pages := slice -}}
+{{- if or $.IsHome $.IsSection -}}
+{{- $pages = $pctx.RegularPages -}}
+{{- else -}}
+{{- $pages = $pctx.Pages -}}
+{{- end -}}
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+{{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    {{- with $.Site.Params.images }}
+    <image>
+      <url>{{ index . 0 | absURL }}</url>
+      <link>{{ index . 0 | absURL }}</link>
+    </image>
+    {{- end }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "RSS" -}}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end -}}
+    {{ range $pages }}
+    {{- if and (ne .Layout `search`) (ne .Layout `archives`) }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ with .Description | html }}{{ . }}{{ else }}{{ .Summary | html }}{{ end -}}</description>
+      {{- if .Site.Params.ShowFullTextinRSS }}
+      <content:encoded>{{ (printf "<![CDATA[%s]]>" .Content) | safeHTML }}</content:encoded>
+      {{- end }}
+    </item>
+    {{- end }}
+    {{ end }}
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary

- Adds `layouts/_default/rss.xml` custom template override to fix Hugo build failure caused by the removal of `.Site.Author` in Hugo v0.157.0
- Removes `<managingEditor>`, `<webMaster>`, and `<author>` RSS fields that used `.Site.Author.email` / `.Site.Author.name` (not configured in `config.yaml`)
- Adds Hugo template terms to `.spelling.txt` to pass cspell checks

## Root Cause

The CI uses `hugo-version: "latest"` which pulled Hugo v0.157.0 (released 2026-02-25). This version removed `.Site.Author` (deprecated in v0.124.0). The PaperMod theme's `rss.xml` template accesses `.Site.Author.email` at line 26, causing a fatal build error.

## Test Plan

- [x] Hugo build passes locally with the override in place
- [x] All pre-commit hooks pass (cspell, markdownlint, prettier, etc.)
- [x] RSS feed (`public/index.xml`) is still generated correctly
- [ ] CI passes on this PR

## Related

Fixes #214
Unblocks #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)