### PR TITLE
docs(content): update talks.md review date to 2026-02-27

### DIFF
--- a/content/talks.md
+++ b/content/talks.md
@@ -1,7 +1,7 @@
 ---
 title: Talks
 date: 2022-04-22T21:00:00+00:00
-reviewed: 2026-02-04
+reviewed: 2026-02-27
 tags: ["talk"]
 author: Lewis Denham-Parry
 showToc: true

--- a/docs/plan/issues/212_page_requires_review_content_talks_md.md
+++ b/docs/plan/issues/212_page_requires_review_content_talks_md.md
@@ -1,0 +1,78 @@
+# GitHub Issue #212: Page requires review: content/talks.md
+
+**Issue:** [#212](https://github.com/denhamparry/website/issues/212) **Status:**
+Complete **Date:** 2026-02-27
+
+## Problem Statement
+
+The `content/talks.md` file requires review to ensure content accuracy and the
+`reviewed` frontmatter date is up-to-date.
+
+### Current Behavior
+
+- Last review date: `2026-02-04` (approximately 3 weeks ago)
+- No new talks have been given since the last review
+- Content is otherwise accurate and up-to-date
+
+### Expected Behavior
+
+- `reviewed` date in frontmatter should reflect today's review date
+- Content confirmed accurate (no new talks to add)
+
+## Current State Analysis
+
+### Relevant Code/Config
+
+**File:** `content/talks.md`
+
+**Current frontmatter:**
+
+```yaml
+---
+title: Talks
+date: 2022-04-22T21:00:00+00:00
+reviewed: 2026-02-04 # ← Needs updating to today's date
+tags: ["talk"]
+author: Lewis Denham-Parry
+# ... other metadata
+---
+```
+
+**Latest talk:** "The Road to Multitenancy: Running Secure Multi-Tenant
+Workloads at Scale" - 14th January 2026
+
+## Solution Design
+
+### Approach
+
+Update the `reviewed` frontmatter field to today's date (`2026-02-27`). No
+content changes needed as no new talks have been given since the last review.
+
+## Implementation Plan
+
+### Step 1: Update reviewed date in frontmatter
+
+**File:** `content/talks.md`
+
+**Change:**
+
+```yaml
+reviewed: 2026-02-27
+```
+
+## Success Criteria
+
+- [x] `reviewed` date updated to `2026-02-27`
+- [x] No unintended content changes
+- [x] Pre-commit hooks pass
+
+## Files Modified
+
+1. `content/talks.md` - Updated `reviewed` date from `2026-02-04` to
+   `2026-02-27`
+
+## References
+
+- [GitHub Issue #212](https://github.com/denhamparry/website/issues/212)
+- Previous review:
+  [Issue #197](https://github.com/denhamparry/website/issues/197)


### PR DESCRIPTION
## Summary

- Updates `reviewed` frontmatter date in `content/talks.md` from `2026-02-04` to `2026-02-27`
- No content changes — no new talks have been given since the last review
- Adds implementation plan document for issue tracking

## Test plan

- [x] Verify `reviewed` date updated to `2026-02-27` in `content/talks.md`
- [x] Confirm no unintended content changes
- [x] Pre-commit hooks pass

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)