### PR TITLE
docs(content): fix broken skillsmatter.com links in talks.md

### DIFF
--- a/.spelling.txt
+++ b/.spelling.txt
@@ -65,7 +65,9 @@ revealjs
 siderolabs
 signup
 Sigstore
+prognet
 skillsmatter
+whova
 SLSA
 blueconf
 Tanzu

--- a/.spelling.txt
+++ b/.spelling.txt
@@ -65,6 +65,7 @@ revealjs
 siderolabs
 signup
 Sigstore
+skillsmatter
 SLSA
 blueconf
 Tanzu

--- a/content/talks.md
+++ b/content/talks.md
@@ -899,8 +899,7 @@ best to monitor your services to put preventative measures in place.
 ### µCon London 2019 - How do we become Cloud Native?
 
 - Type: Talk
-- Where:
-  [London, UK](https://skillsmatter.com/conferences/11982-con-london-2019-the-conference-on-microservices-ddd-and-software-architecture#program)
+- Where: London, UK
 
 ### KubeCon EU - How we contributed to the community with no code
 
@@ -1040,8 +1039,7 @@ influx of messages in the queue.
 ### µCon London 2018 - One Monolith / One Macroservice / Many Microservices
 
 - Type: Talk
-- Where:
-  [London, UK](https://skillsmatter.com/conferences/10336-mucon-london-2018-the-microservices-conference#skillscasts)
+- Where: London, UK
 - Date: 05th November 2018
 
 From working with a number of companies, the only constant is seeing that each
@@ -1067,8 +1065,7 @@ perspective, and plan how to convert this macroservice into microservices.
 ### ProgNet London 2018 - Use Kubernetes to Deploy .NET Applications
 
 - Type: Workshop
-- Where:
-  [London, UK](https://skillsmatter.com/conferences/10107-prognet-london-2018#skillscasts).
+- Where: London, UK.
 - Date: 12th September 2018.
 
 With the explosive momentum of Docker, Kubernetes has become the de-facto

--- a/docs/plan/issues/218_broken_links_detected_in_talks_md.md
+++ b/docs/plan/issues/218_broken_links_detected_in_talks_md.md
@@ -1,0 +1,234 @@
+# GitHub Issue #218: Broken links detected in talks.md
+
+**Issue:** [#218](https://github.com/denhamparry/website/issues/218) **Status:**
+Planning **Date:** 2026-03-02
+
+## Problem Statement
+
+The monthly link checker workflow detected broken links in `content/talks.md`.
+All three broken links point to skillsmatter.com, which returned `403 Forbidden`
+responses. SkillsMatter went into administration and their website is no longer
+functional.
+
+### Current Behavior
+
+Three links in `content/talks.md` return 403 Forbidden from lychee's
+perspective, causing the link checker workflow to fail and create this automated
+issue.
+
+**Broken links identified:**
+
+1. `https://skillsmatter.com/conferences/11982-con-london-2019-the-conference-on-microservices-ddd-and-software-architecture#program`
+   - Talk: µCon London 2019 - How do we become Cloud Native? (line ~903)
+2. `https://skillsmatter.com/conferences/10107-prognet-london-2018#skillscasts`
+   - Talk: ProgNet London 2018 - Use Kubernetes to Deploy .NET Applications
+     (line ~1071)
+3. `https://skillsmatter.com/conferences/10336-mucon-london-2018-the-microservices-conference#skillscasts`
+   - Talk: µCon London 2018 - One Monolith / One Macroservice / Many
+     Microservices (line ~1044)
+
+### Expected Behavior
+
+- All links in `content/talks.md` return HTTP 200 or 429
+- The monthly link checker workflow passes without failures
+- GitHub issue #218 is resolved and closed
+
+## Current State Analysis
+
+### Relevant Code/Config
+
+- **File:** `content/talks.md` - Contains all talk entries with links
+- **File:** `.lychee.toml` - Link checker config: `accept = [200, 429]` only
+- **File:** `.github/workflows/link-check.yml` - Monthly link check workflow
+
+### Root Cause
+
+SkillsMatter (skillsmatter.com) went into administration. Their website is no
+longer operational and returns 403 for all requests. These links are from 2018
+and 2019 conference appearances.
+
+### Related Context
+
+- Previous similar issues: #205 (broken links Jan 2025), #209 (broken links
+  Feb 2026)
+- The lychee config accepts only 200 and 429 - 403 always fails
+
+## Solution Design
+
+### Approach
+
+Replace the three broken skillsmatter.com links with web.archive.org archived
+versions. This preserves the historical record while fixing the broken links.
+Archive.org typically has snapshots of these pages.
+
+If archive.org does not have a usable snapshot for any link, remove the link
+text entirely and keep just the plain text event name.
+
+### Rationale
+
+- Archive.org links are stable and return 200
+- Preserves the event history and context for visitors
+- Consistent with how other archived links are handled in the file (see BSides
+  London 2021 which already uses archive.org)
+
+### Implementation
+
+For each of the three links, replace with the archive.org equivalent URL.
+
+The archive.org URL format is:
+`https://web.archive.org/web/<YYYYMMDDHHMMSS>/<original-url>`
+
+## Implementation Plan
+
+### Step 1: Find archive.org URLs for each broken link
+
+Check web.archive.org for archived snapshots of:
+
+1. `https://web.archive.org/web/*/https://skillsmatter.com/conferences/11982-con-london-2019-the-conference-on-microservices-ddd-and-software-architecture`
+2. `https://web.archive.org/web/*/https://skillsmatter.com/conferences/10107-prognet-london-2018`
+3. `https://web.archive.org/web/*/https://skillsmatter.com/conferences/10336-mucon-london-2018-the-microservices-conference`
+
+### Step 2: Update content/talks.md
+
+**File:** `content/talks.md`
+
+Replace each broken skillsmatter.com link with the corresponding archive.org URL
+(or remove the link if no archive exists).
+
+**Change 1** (~line 903): µCon London 2019
+
+```markdown
+# Before:
+
+- Where:
+  [London, UK](https://skillsmatter.com/conferences/11982-con-london-2019-the-conference-on-microservices-ddd-and-software-architecture#program)
+
+# After (example with archive.org):
+
+- Where:
+  [London, UK](https://web.archive.org/web/20190601000000*/https://skillsmatter.com/conferences/11982-con-london-2019-the-conference-on-microservices-ddd-and-software-architecture)
+```
+
+**Change 2** (~line 1044): µCon London 2018
+
+```markdown
+# Before:
+
+- Where:
+  [London, UK](https://skillsmatter.com/conferences/10336-mucon-london-2018-the-microservices-conference#skillscasts)
+
+# After (example with archive.org):
+
+- Where:
+  [London, UK](https://web.archive.org/web/20181101000000*/https://skillsmatter.com/conferences/10336-mucon-london-2018-the-microservices-conference)
+```
+
+**Change 3** (~line 1071): ProgNet London 2018
+
+```markdown
+# Before:
+
+- Where:
+  [London, UK](https://skillsmatter.com/conferences/10107-prognet-london-2018#skillscasts).
+
+# After (example with archive.org):
+
+- Where:
+  [London, UK](https://web.archive.org/web/20180912000000*/https://skillsmatter.com/conferences/10107-prognet-london-2018).
+```
+
+### Step 3: Verify fixes
+
+```bash
+# Build hugo site to check for errors
+hugo --gc --minify
+
+# Run pre-commit hooks
+pre-commit run --all-files
+```
+
+### Step 4: Commit and PR
+
+Stage only the modified file and create a conventional commit on the
+`denhamparry.co.uk/docs/gh-issue-218` branch.
+
+## Testing Strategy
+
+### Manual Verification
+
+For each replaced link, verify the archive.org URL returns HTTP 200:
+
+```bash
+curl -sI "<archive-url>" | head -1
+```
+
+### Integration Testing
+
+**Test Case 1: Local link check**
+
+```bash
+# Build first
+hugo --gc --minify
+# Check links (requires lychee installed locally)
+lychee --accept 200,429 content/**/*.md
+```
+
+**Test Case 2: PR preview**
+
+- PR will trigger the link checker workflow on preview build
+- Verify workflow passes in GitHub Actions
+
+### Regression Testing
+
+- Verify no other links in talks.md were accidentally modified
+- Check that the three replaced talks still display correctly on the site
+
+## Success Criteria
+
+- [ ] All three skillsmatter.com links replaced with working alternatives
+- [ ] `content/talks.md` has no other modifications
+- [ ] Pre-commit hooks pass
+- [ ] Archive.org links return HTTP 200
+- [ ] Link checker workflow passes on the PR
+- [ ] Issue #218 closed after merge
+
+## Files Modified
+
+1. `content/talks.md` - Replace 3 broken skillsmatter.com links with archive.org
+   URLs
+
+## Related Issues and Tasks
+
+### Related
+
+- #205 - Broken links detected in content files (Jan 2025)
+- #209 - Broken links detected in talks.md (Feb 2026)
+
+### Closes
+
+- #218 - Broken links detected in talks.md
+
+## References
+
+- [GitHub Issue #218](https://github.com/denhamparry/website/issues/218)
+- [Workflow Run](https://github.com/denhamparry/website/actions/runs/22532369829)
+- [Wayback Machine](https://web.archive.org/)
+
+## Notes
+
+### Key Insights
+
+- SkillsMatter went into administration; all skillsmatter.com URLs are broken
+- The existing `.lychee.toml` only accepts 200 and 429 - 403 always fails
+- BSides London 2021 entry already uses `web.archive.org` as a precedent
+- The `#skillscasts` and `#program` fragment identifiers may not work in
+  archive.org URLs - use the base URL without fragments
+
+### Alternative Approaches Considered
+
+1. **Add skillsmatter.com to lychee exclusions** - Not chosen because the links
+   are genuinely broken and users would hit dead links ❌
+2. **Remove links entirely** - Not chosen as archive.org preserves historical
+   context ✅ (preferred when archive exists)
+3. **Replace with archive.org links** - Chosen: stable, returns 200, preserves
+   history ✅

--- a/docs/plan/issues/218_broken_links_detected_in_talks_md.md
+++ b/docs/plan/issues/218_broken_links_detected_in_talks_md.md
@@ -1,7 +1,7 @@
 # GitHub Issue #218: Broken links detected in talks.md
 
 **Issue:** [#218](https://github.com/denhamparry/website/issues/218) **Status:**
-Reviewed (Approved) **Date:** 2026-03-02
+Complete **Date:** 2026-03-02
 
 ## Problem Statement
 

--- a/docs/plan/issues/218_broken_links_detected_in_talks_md.md
+++ b/docs/plan/issues/218_broken_links_detected_in_talks_md.md
@@ -1,7 +1,7 @@
 # GitHub Issue #218: Broken links detected in talks.md
 
 **Issue:** [#218](https://github.com/denhamparry/website/issues/218) **Status:**
-Planning **Date:** 2026-03-02
+Reviewed (Approved) **Date:** 2026-03-02
 
 ## Problem Statement
 
@@ -232,3 +232,145 @@ lychee --accept 200,429 content/**/*.md
    context ✅ (preferred when archive exists)
 3. **Replace with archive.org links** - Chosen: stable, returns 200, preserves
    history ✅
+
+---
+
+## Plan Review
+
+**Reviewer:** Claude Code (workflow-research-plan) **Review Date:** 2026-03-02
+**Original Plan Date:** 2026-03-02
+
+### Review Summary
+
+- **Overall Assessment:** Approved (with required changes)
+- **Confidence Level:** High
+- **Recommendation:** Proceed to implementation with updated approach
+
+### Critical Finding: Archive.org Has No Snapshots
+
+Independent research via the Wayback Machine availability API confirms that
+**none of the three skillsmatter.com pages are archived**:
+
+1. `skillsmatter.com/conferences/11982-con-london-2019-...` →
+   `archived_snapshots: {}`
+2. `skillsmatter.com/conferences/10107-prognet-london-2018` →
+   `archived_snapshots: {}`
+3. `skillsmatter.com/conferences/10336-mucon-london-2018-...` →
+   `archived_snapshots: {}`
+
+The entire `skillsmatter.com` domain has no captured snapshots in archive.org.
+
+**Impact**: The plan's primary approach (replace with archive.org links) is not
+feasible. The fallback approach (remove links, keep plain text) MUST be used for
+all three links.
+
+### Strengths
+
+1. **Correct problem identification**: All three broken links correctly
+   identified from workflow logs
+2. **Fallback logic exists**: Plan correctly anticipates the case where
+   archive.org has no snapshot and specifies removing links
+3. **Conservative scope**: Only modifies `content/talks.md`, no other files
+4. **Consistent with project conventions**: Follows the same pattern used in
+   issue #209 resolution
+5. **No risk of introducing new broken links**: Removing URLs entirely is safe
+
+### Required Changes
+
+**The following update must be reflected during implementation (plan need not be
+rewritten — implement the fallback path directly):**
+
+- [ ] Since no archive.org snapshots exist, **remove all three broken links**
+      rather than replacing them
+- [ ] For µCon London 2019: Remove the `Where:` field URL, change to plain text
+- [ ] For µCon London 2018: Remove the URL from the `Where:` field
+- [ ] For ProgNet London 2018: Remove the URL from the `Where:` field
+- [ ] The URL format issue in plan examples (using `*` which is a calendar page,
+      not a direct snapshot) is moot since no archives exist
+
+### Concrete Implementation Changes
+
+Since archive.org has no snapshots, the three edits needed are:
+
+**Change 1** — µCon London 2019 (~line 903):
+
+```markdown
+# Before:
+
+- Where:
+  [London, UK](https://skillsmatter.com/conferences/11982-con-london-2019-the-conference-on-microservices-ddd-and-software-architecture#program)
+
+# After:
+
+- Where: London, UK
+```
+
+**Change 2** — µCon London 2018 (~line 1044):
+
+```markdown
+# Before:
+
+- Where:
+  [London, UK](https://skillsmatter.com/conferences/10336-mucon-london-2018-the-microservices-conference#skillscasts)
+
+# After:
+
+- Where: London, UK
+```
+
+**Change 3** — ProgNet London 2018 (~line 1071):
+
+```markdown
+# Before:
+
+- Where:
+  [London, UK](https://skillsmatter.com/conferences/10107-prognet-london-2018#skillscasts).
+
+# After:
+
+- Where: London, UK.
+```
+
+### Edge Cases Verified
+
+1. **Other broken links**: Only the three skillsmatter.com links were flagged by
+   the workflow run. No other links in talks.md returned errors.
+2. **OWASP AppSec EU whova.com link** (~line 400): Not flagged — returns 200 or
+   accepted status.
+3. **Removing Where: field vs. keeping plain text**: Keeping
+   `- Where: London, UK` maintains consistent formatting with other entries.
+
+### Alternative Approaches
+
+1. **Add skillsmatter.com to lychee exclusions** — Rejected. Links are genuinely
+   dead; exclusions would hide the problem from visitors.
+2. **Remove entire talk entries** — Rejected. Historical record has value even
+   without event URLs.
+3. **Replace with archive.org links** — Not feasible; no snapshots exist.
+4. **Plain text location (chosen)** — Best option: maintains event record,
+   removes dead links, clean formatting.
+
+### Verification Checklist
+
+- [x] Solution addresses root cause (3 broken skillsmatter.com links)
+- [x] Archive.org availability independently verified (no snapshots)
+- [x] Fallback approach is correctly specified in plan
+- [x] File paths and line numbers verified against actual file
+- [x] Security implications N/A (documentation only)
+- [x] Performance impact N/A (no code changes)
+- [x] Test strategy adequate (pre-commit hooks + PR CI)
+- [x] No breaking changes
+- [x] Consistent with prior issue #209 resolution pattern
+
+### Optional Improvements
+
+- [ ] Run full link check on all content files after the fix to catch any other
+      broken links proactively
+- [ ] Consider adding a comment to `.lychee.toml` documenting that
+      skillsmatter.com is permanently down
+
+---
+
+**Review completed by Claude Code workflow-research-plan** **Confidence: High**
+| **Recommendation: Proceed to implementation (remove links, no archive
+available)**


### PR DESCRIPTION
## Summary

Removes three dead links to skillsmatter.com from `content/talks.md`. SkillsMatter went into administration and their website is no longer operational — all three URLs return HTTP 403 and no archive.org snapshots exist for these pages.

## Changes Made

- Removed broken link for **µCon London 2019 - How do we become Cloud Native?** (skillsmatter.com/conferences/11982...)
- Removed broken link for **µCon London 2018 - One Monolith / One Macroservice / Many Microservices** (skillsmatter.com/conferences/10336...)
- Removed broken link for **ProgNet London 2018 - Use Kubernetes to Deploy .NET Applications** (skillsmatter.com/conferences/10107...)
- Replaced all three with plain text `- Where: London, UK` to preserve the historical event record
- Added `skillsmatter`, `prognet`, and `whova` to `.spelling.txt` (needed for plan docs)

## Motivation

The monthly link checker detected these three 403 failures and automatically created issue #218. Archive.org has no snapshots of skillsmatter.com, so replacing links with archived versions is not possible — plain text location is the correct fallback per project conventions.

## Testing

- [x] All pre-commit hooks pass (markdownlint, cspell, prettier, gitleaks)
- [x] No other links in `talks.md` were affected
- [x] Consistent formatting with other entries in the file
- [x] Follows the same pattern used to resolve issue #209

## Breaking Changes

None — documentation only.

## Related Issues

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)