### PR TITLE
docs(content): remove broken Zoom webinar sign-up link from talks

### DIFF
--- a/content/talks.md
+++ b/content/talks.md
@@ -91,8 +91,6 @@ an AI agent to write all the code.
 - Type: Webinar
 - Date: 16th October 2025
 - Event: Edera Runtime Rumble
-- Resources:
-  [Sign up link](https://us06web.zoom.us/webinar/register/4017575425840/WN_viySTZz6Tr2-yzSjpWS6eQ#/registration)
 
 Confidential Computing promises hardware-based security for sensitive
 workloads—but adoption hurdles and misconceptions remain. In this webinar,


### PR DESCRIPTION
## Summary

- Remove broken Zoom webinar registration link (404) from `content/talks.md`
- The "Tag Team Champions: Confidential Computing meets Edera" webinar (Oct 2025) has passed and the registration page no longer exists
- No recording URL is available, so the Resources line is removed entirely

## Test plan

- [x] Pre-commit hooks pass
- [x] Link checker should pass without the broken URL
- [x] Content structure remains consistent with other talk entries

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)