### PR TITLE
fix(ci): pin GitHub Actions to SHA digests for supply chain security

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,12 +25,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude PR Action
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: "60"

--- a/.github/workflows/conform.yml
+++ b/.github/workflows/conform.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # Required for conventional commit validation
       - name: Conform Action
-        uses: siderolabs/conform@v0.1.0-alpha.30
+        uses: siderolabs/conform@cfdb3cce90daece912e6a5cb3f20b2316a78a5bf # v0.1.0-alpha.31

--- a/.github/workflows/create-issues-for-outdated-pages.yml
+++ b/.github/workflows/create-issues-for-outdated-pages.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: "0" # Fetch all history for all tags and branches
 
@@ -53,7 +53,7 @@ jobs:
 
       - name:
           Check and create GitHub issue if an issue for a page does not exist
-        uses: actions/github-script@v6
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         if: (steps.find-outdated-pages.outputs.PAGES)
         env:
           PAGES: "${{ steps.find-outdated-pages.outputs.PAGES }}"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Check links in content/
-        uses: lycheeverse/lychee-action@v2.0.2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >-
             --verbose --no-progress --max-retries 3 --timeout 5 --accept 200,429
@@ -27,7 +27,7 @@ jobs:
 
       - name: Create issue if links broken
         if: failure()
-        uses: actions/github-script@v6
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           LABELS: '["documentation", "help wanted"]'
           ASSIGNEES: '["denhamparry"]'

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "18"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,25 +20,25 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true # Fetch Hugo themes
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@16361eb4acea8698b220b76c0d4e84e1fd22c61d # v2.6.0
         with:
           hugo-version: "latest"
           extended: true
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
 
       - name: Cache Puppeteer browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/puppeteer
           key: ${{ runner.os }}-puppeteer-${{ hashFiles('package-lock.json') }}
@@ -60,7 +60,7 @@ jobs:
         run: hugo --gc --minify
 
       - name: Upload Hugo build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: hugo-public
           path: public/
@@ -91,7 +91,7 @@ jobs:
           fi
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: test-results-${{ matrix.node-version }}
@@ -104,10 +104,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Validate HTML
-        uses: Cyb3r-Jak3/html5validator-action@v7.2.0
+        uses: Cyb3r-Jak3/html5validator-action@41633d488eb36e18fd1a95ffc83daf1bf22a75bd # v7.2.0
         with:
           root: public/
         continue-on-error: true
@@ -119,7 +119,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2 # Need 2 commits for diff
 
@@ -134,20 +134,20 @@ jobs:
 
       - name: Download Hugo build
         if: steps.content-changed.outputs.changed == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: hugo-public
           path: public/
 
       - name: Setup Hugo
         if: steps.content-changed.outputs.changed == 'true'
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@16361eb4acea8698b220b76c0d4e84e1fd22c61d # v2.6.0
         with:
           hugo-version: "latest"
 
       - name: Setup Node.js
         if: steps.content-changed.outputs.changed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20.x"
 
@@ -168,12 +168,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@16361eb4acea8698b220b76c0d4e84e1fd22c61d # v2.6.0
         with:
           hugo-version: "latest"
 
@@ -181,7 +181,7 @@ jobs:
         run: hugo --gc --minify --buildFuture
 
       - name: Deploy to Netlify Preview
-        uses: nwtgck/actions-netlify@v2.0
+        uses: nwtgck/actions-netlify@7a92f00dde8c92a5a9e8385ec2919775f7647352 # v2.1.0
         with:
           publish-dir: "./public"
           production-deploy: false

--- a/docs/plan/issues/226_pin_github_actions_to_sha.md
+++ b/docs/plan/issues/226_pin_github_actions_to_sha.md
@@ -1,0 +1,71 @@
+# Plan: Pin GitHub Actions to SHA Digests
+
+- **Issue:** #226
+- **Status:** In Progress
+- **Branch:** denhamparry.co.uk/fix/gh-issue-226
+- **Type:** Security hardening
+
+## Problem
+
+All GitHub Actions in this repository use mutable version tags (`@v4`, `@beta`,
+`@v2`) instead of immutable SHA digests. A compromised upstream action
+maintainer could push malicious code to an existing tag, affecting all workflows
+that reference it.
+
+## Solution
+
+Pin every `uses:` reference to its full 40-character commit SHA, with a human-
+readable version comment. Also upgrade stale references:
+
+- `actions/checkout@v3` -> v4 (create-issues-for-outdated-pages.yml)
+- `actions/github-script@v6` -> v7 (create-issues-for-outdated-pages.yml,
+  link-check.yml)
+- `lycheeverse/lychee-action@v2.0.2` -> v2.8.0
+
+## SHA Reference Table
+
+| Action                           | Pin SHA                                  | Version         |
+| -------------------------------- | ---------------------------------------- | --------------- |
+| actions/checkout                 | 34e114876b0b11c390a56381ad16ebd13914f8d5 | v4.3.1          |
+| actions/setup-node               | 49933ea5288caeca8642d1e84afbd3f7d6820020 | v4.4.0          |
+| actions/cache                    | 0057852bfaa89a56745cba8c7296529d2fc39830 | v4.3.0          |
+| actions/upload-artifact          | ea165f8d65b6e75b540449e92b4886f43607fa02 | v4.6.2          |
+| actions/download-artifact        | d3f86a106a0bac45b974a628896c90dbdf5c8093 | v4.3.0          |
+| actions/github-script            | f28e40c7f34bde8b3046d885e986cb6290c5673b | v7.1.0          |
+| anthropics/claude-code-action    | 28f83620103c48a57093dcc2837eec89e036bb9f | beta            |
+| siderolabs/conform               | cfdb3cce90daece912e6a5cb3f20b2316a78a5bf | v0.1.0-alpha.31 |
+| peaceiris/actions-hugo           | 16361eb4acea8698b220b76c0d4e84e1fd22c61d | v2.6.0          |
+| Cyb3r-Jak3/html5validator-action | 41633d488eb36e18fd1a95ffc83daf1bf22a75bd | v7.2.0          |
+| lycheeverse/lychee-action        | 8646ba30535128ac92d33dfc9133794bfdd9b411 | v2.8.0          |
+| nwtgck/actions-netlify           | 7a92f00dde8c92a5a9e8385ec2919775f7647352 | v2.1.0          |
+
+## Files Modified
+
+- `.github/workflows/claude.yml`
+- `.github/workflows/conform.yml`
+- `.github/workflows/create-issues-for-outdated-pages.yml`
+- `.github/workflows/link-check.yml`
+- `.github/workflows/misspell.yml`
+- `.github/workflows/test.yml`
+
+## Implementation Steps
+
+1. Pin actions in `claude.yml` (checkout, claude-code-action)
+2. Pin actions in `conform.yml` (checkout, conform)
+3. Pin actions in `create-issues-for-outdated-pages.yml` (checkout v3->v4,
+   github-script v6->v7)
+4. Pin actions in `link-check.yml` (checkout, lychee-action, github-script
+   v6->v7)
+5. Pin actions in `misspell.yml` (checkout, setup-node)
+6. Pin actions in `test.yml` (checkout, hugo, setup-node, cache,
+   upload-artifact, download-artifact, html5validator, netlify)
+7. Run pre-commit hooks
+8. Commit changes
+
+## Acceptance Criteria
+
+- [ ] All `uses:` references pinned to full SHA digests
+- [ ] Each pinned reference has a version comment (e.g. `# v4.3.1`)
+- [ ] `actions/checkout@v3` upgraded to v4
+- [ ] `actions/github-script@v6` upgraded to v7
+- [ ] Pre-commit hooks pass


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions `uses:` references to immutable SHA digests instead of mutable version tags (`@v4`, `@beta`, etc.)
- Upgrade `actions/checkout@v3` to v4, `actions/github-script@v6` to v7, `lycheeverse/lychee-action` to v2.8.0
- Add version comments (e.g. `# v4.3.1`) alongside each SHA for human readability

## Affected Workflows

All 6 workflow files updated:
- `claude.yml` (2 actions)
- `conform.yml` (2 actions)
- `create-issues-for-outdated-pages.yml` (2 actions)
- `link-check.yml` (3 actions)
- `misspell.yml` (2 actions)
- `test.yml` (13 action references)

## Why

Mutable tags are a supply chain risk — a compromised upstream action maintainer could push malicious code to an existing tag. SHA pinning makes builds deterministic and tamper-proof. See [GitHub's security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## Test plan

- [ ] All CI workflows pass (pre-commit, conform, test)
- [ ] No workflow syntax errors
- [ ] Verify SHA digests resolve correctly

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)