### PR TITLE
fix(deps): update npm dependencies with known advisories

### DIFF
--- a/docs/plan/issues/229_review_update_npm_dependencies.md
+++ b/docs/plan/issues/229_review_update_npm_dependencies.md
@@ -11,10 +11,11 @@ labels: dependencies, javascript, security
 
 ## Summary
 
-A Shoulder.dev scan and `npm audit` identified 3 vulnerable packages (6 total
-advisories) in the project's devDependencies. All affected packages are used
-exclusively in the testing/development pipeline and are not bundled into the
-production Hugo site output.
+A Shoulder.dev scan and `npm audit` identified 3 vulnerable packages with 5
+distinct advisories (brace-expansion appears at two dependency tree locations)
+in the project's devDependencies. All affected packages are used exclusively in
+the testing/development pipeline and are not bundled into the production Hugo
+site output.
 
 ## Current State (npm audit findings)
 
@@ -63,7 +64,7 @@ npm install --save-dev --save-exact axios@1.15.0
 ```
 
 **Validation**: Verify no breaking changes in axios changelog between 1.9.0 and
-1.15.0. The update is a minor version bump within the 1.x range.
+1.15.0. The update stays within the same major version (1.x).
 
 ### Step 2: Fix transitive dependencies via npm audit fix
 
@@ -105,10 +106,10 @@ Confirm cspell (which depends on yaml transitively) still functions correctly.
 
 ## Files Modified
 
-| File                | Change                                                                              |
-| ------------------- | ----------------------------------------------------------------------------------- |
-| `package.json`      | Update axios version from `1.9.0` to `1.15.0`                                       |
-| `package-lock.json` | Updated lock file reflecting axios 1.15.0, brace-expansion 1.1.13/2.0.3, yaml 2.8.3 |
+| File                | Change                                                                                                                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `package.json`      | Update axios version from `1.9.0` to `1.15.0`                                                                                                                             |
+| `package-lock.json` | Updated lock file reflecting axios 1.15.0 and its updated transitive dependencies (follow-redirects, form-data, proxy-from-env), brace-expansion 1.1.13/2.0.3, yaml 2.8.3 |
 
 ## Acceptance Criteria
 

--- a/docs/plan/issues/229_review_update_npm_dependencies.md
+++ b/docs/plan/issues/229_review_update_npm_dependencies.md
@@ -1,0 +1,198 @@
+---
+status: Complete
+issue: 229
+title: Review and update npm dependencies with known advisories
+labels: dependencies, javascript, security
+---
+
+<!-- cspell:ignore GHSA xvwj qjmp exploitability worktree -->
+
+# Issue #229: Review and Update npm Dependencies with Known Advisories
+
+## Summary
+
+A Shoulder.dev scan and `npm audit` identified 3 vulnerable packages (6 total
+advisories) in the project's devDependencies. All affected packages are used
+exclusively in the testing/development pipeline and are not bundled into the
+production Hugo site output.
+
+## Current State (npm audit findings)
+
+### 1. axios (Direct dependency)
+
+- **Installed**: 1.9.0
+- **Pinned in package.json**: 1.9.0 (exact)
+- **Fix version**: 1.15.0
+- **Severity**: High (2 high, 1 moderate)
+
+| Advisory                                                                                                           | Severity | CVSS | CWE     | Fixed in |
+| ------------------------------------------------------------------------------------------------------------------ | -------- | ---- | ------- | -------- |
+| [GHSA-4hjh-wcwx-xvwj](https://github.com/advisories/GHSA-4hjh-wcwx-xvwj) - DoS via lack of data size check         | High     | 7.5  | CWE-770 | 1.12.0   |
+| [GHSA-43fc-jf86-j433](https://github.com/advisories/GHSA-43fc-jf86-j433) - DoS via `__proto__` key in mergeConfig  | High     | 7.5  | CWE-754 | 1.13.5   |
+| [GHSA-qj83-cq47-w5f8](https://github.com/advisories/GHSA-qj83-cq47-w5f8) - HTTP/2 session cleanup state corruption | Moderate | 5.9  | CWE-400 | 1.13.2   |
+
+### 2. brace-expansion (Transitive dependency)
+
+- **Installed**: 1.1.12 (root, via minimatch) and 2.0.2 (linkinator subtree)
+- **Fix versions**: 1.1.13 and 2.0.3 respectively
+- **Severity**: Moderate
+
+| Advisory                                                                                                                                | Severity | CVSS | CWE     | Fixed in       |
+| --------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---- | ------- | -------------- |
+| [GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v) - Zero-step sequence causes process hang and memory exhaustion | Moderate | 6.5  | CWE-400 | 1.1.13 / 2.0.3 |
+
+### 3. yaml (Transitive dependency, via cspell)
+
+- **Installed**: 2.8.0
+- **Fix version**: 2.8.3
+- **Severity**: Moderate
+
+| Advisory                                                                                                                     | Severity | CVSS | CWE     | Fixed in |
+| ---------------------------------------------------------------------------------------------------------------------------- | -------- | ---- | ------- | -------- |
+| [GHSA-48c2-rrv3-qjmp](https://github.com/advisories/GHSA-48c2-rrv3-qjmp) - Stack overflow via deeply nested YAML collections | Moderate | 4.3  | CWE-674 | 2.8.3    |
+
+## Implementation Tasks
+
+### Step 1: Update axios (direct dependency)
+
+Update the pinned version in `package.json` from `1.9.0` to `1.15.0` (latest
+available, resolves all 3 advisories).
+
+```bash
+npm install --save-dev --save-exact axios@1.15.0
+```
+
+**Validation**: Verify no breaking changes in axios changelog between 1.9.0 and
+1.15.0. The update is a minor version bump within the 1.x range.
+
+### Step 2: Fix transitive dependencies via npm audit fix
+
+Run `npm audit fix` to resolve brace-expansion and yaml vulnerabilities. This
+updates the lock file without changing `package.json` semver ranges (the
+transitive deps are not direct dependencies).
+
+```bash
+npm audit fix
+```
+
+**Expected result**: brace-expansion updates to 1.1.13 / 2.0.3 and yaml updates
+to 2.8.3 in `package-lock.json`.
+
+### Step 3: Verify clean audit
+
+```bash
+npm audit
+```
+
+Confirm 0 vulnerabilities reported.
+
+### Step 4: Run test suite
+
+```bash
+npm test
+```
+
+Confirm all tests (Hugo build, functional, accessibility) still pass with
+updated dependencies.
+
+### Step 5: Run spell check
+
+```bash
+npm run test:spell
+```
+
+Confirm cspell (which depends on yaml transitively) still functions correctly.
+
+## Files Modified
+
+| File                | Change                                                                              |
+| ------------------- | ----------------------------------------------------------------------------------- |
+| `package.json`      | Update axios version from `1.9.0` to `1.15.0`                                       |
+| `package-lock.json` | Updated lock file reflecting axios 1.15.0, brace-expansion 1.1.13/2.0.3, yaml 2.8.3 |
+
+## Acceptance Criteria
+
+1. `npm audit` reports 0 vulnerabilities
+2. `npm test` passes (Hugo build, functional, accessibility tests)
+3. `npm run test:spell` passes (cspell with updated yaml dependency)
+4. No changes to production site output (these are devDependencies only)
+5. `package.json` axios version updated to 1.15.0 (exact pin maintained)
+6. `package-lock.json` reflects all patched transitive dependency versions
+
+## Risk Assessment
+
+**Overall risk: Low**
+
+- **Production impact: None** - All 3 affected packages are devDependencies used
+  only during testing and CI. They are never bundled into the Hugo static site
+  output deployed to Netlify.
+- **axios update**: Minor version bump (1.9.0 to 1.15.0) within the same major
+  version. Used in functional tests only. Low risk of breaking changes.
+- **brace-expansion update**: Patch-level bumps (1.1.12 to 1.1.13, 2.0.2 to
+  2.0.3). Minimal risk.
+- **yaml update**: Patch-level bump (2.8.0 to 2.8.3). Transitive dependency of
+  cspell. Minimal risk.
+- **Exploitability context**: The DoS vulnerabilities in axios and
+  brace-expansion require attacker-controlled input to exploit. In a CI/testing
+  context with controlled inputs, the practical exploitability is very low.
+  However, updating is still recommended as a best practice.
+
+## Critical Review
+
+**Reviewer**: Claude Opus 4.6 (1M context) **Date**: 2026-04-09 **Verdict**:
+Approved
+
+### Verification Results
+
+1. **package.json state matches plan**: Confirmed axios is pinned at exactly
+   `1.9.0` as a devDependency. All other devDependencies match the plan's
+   assumptions.
+
+2. **npm audit output matches plan**: `npm audit --json` confirms exactly 3
+   vulnerable packages:
+
+   - **axios**: 3 advisories (GHSA-4hjh-wcwx-xvwj high, GHSA-43fc-jf86-j433
+     high, GHSA-qj83-cq47-w5f8 moderate). Fix available: 1.15.0. Matches plan.
+   - **brace-expansion**: 2 advisory sources (same GHSA-f886-m6hf-6m8v for
+     ranges <1.1.13 and >=2.0.0 <2.0.3). Nodes at root and linkinator subtree.
+     Matches plan.
+   - **yaml**: 1 advisory (GHSA-48c2-rrv3-qjmp, range 2.0.0-2.8.2). Matches
+     plan.
+
+3. **axios 1.15.0 exists**: Confirmed via `npm view axios versions`. 1.15.0 is
+   the latest published version. The target version is valid and available.
+
+4. **Fix is semver-minor**: axios 1.9.0 to 1.15.0 is a minor version bump within
+   the same major. npm audit confirms `isSemVerMajor: false`.
+
+### Assessment
+
+**Approach is sound and complete.** The plan correctly identifies all
+vulnerabilities, proposes the right fix versions, and follows a sensible
+execution order (direct dep first, then transitive via audit fix, then verify).
+
+### Minor Observations (Non-blocking)
+
+- **Advisory count phrasing**: The summary says "6 total advisories" which
+  counts individual advisory sources across all packages. npm audit metadata
+  reports `total: 3` (counting unique vulnerable packages). Both readings are
+  defensible; just noting the distinction for clarity.
+
+- **node_modules not present in worktree**: The worktree does not currently have
+  `node_modules` installed. Step 1
+  (`npm install --save-dev --save-exact axios@1.15.0`) will handle this
+  implicitly, but the implementer should run `npm install` first if they want a
+  clean baseline comparison, or simply proceed with the plan as written since
+  npm install is implicit in the update command.
+
+- **npm audit fix scope**: `npm audit fix` may update more transitive
+  dependencies than just brace-expansion and yaml if new advisories have
+  appeared since the plan was written. This is acceptable and expected behavior
+  for a security update.
+
+### Conclusion
+
+The plan is well-structured, accurately reflects the current vulnerability
+state, targets valid fix versions, and has appropriate risk assessment. The
+scope is limited to devDependencies with no production impact. Approved for
+implementation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@axe-core/puppeteer": "4.10.2",
-        "axios": "1.9.0",
+        "axios": "1.15.0",
         "chalk": "4.1.2",
         "cspell": "8.19.4",
         "jest": "29.7.0",
@@ -1807,15 +1807,25 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": ">=4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/b4a": {
@@ -2057,9 +2067,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3355,9 +3365,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "dev": true,
       "funding": [
         {
@@ -3376,9 +3386,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4775,9 +4785,9 @@
       }
     },
     "node_modules/linkinator/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6329,9 +6339,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6339,6 +6349,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@axe-core/puppeteer": "4.10.2",
-    "axios": "1.9.0",
+    "axios": "1.15.0",
     "chalk": "4.1.2",
     "cspell": "8.19.4",
     "jest": "29.7.0",


### PR DESCRIPTION
## Summary

- Update axios from 1.9.0 to 1.15.0 to resolve 3 advisories (2 high, 1 moderate DoS vulnerabilities)
- Fix transitive vulnerabilities in brace-expansion (1.1.12→1.1.13, 2.0.2→2.0.3) and yaml (2.8.0→2.8.3) via npm audit fix
- All affected packages are devDependencies only — zero production impact on the deployed Hugo site

## Test plan

- [x] `npm audit` reports 0 vulnerabilities
- [x] Pre-commit hooks pass
- [ ] CI tests pass (Hugo build, functional, accessibility)
- [ ] All acceptance criteria from issue #229 met

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)