### PR TITLE
fix(website): serve 410 for removed legacy URLs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -5,7 +5,9 @@ https://denhamparry.netlify.com/* https://denhamparry.co.uk/:splat 301!
 http://blog.denhamparry.co.uk/* https://denhamparry.co.uk/:splat 301!
 https://blog.denhamparry.co.uk/* https://denhamparry.co.uk/:splat 301!
 
-# Redirect all old blog posts and pages to homepage
-https://denhamparry.co.uk/posts/* https://denhamparry.co.uk/:splat 301!
-https://denhamparry.co.uk/page/* https://denhamparry.co.uk/:splat 301!
-https://denhamparry.co.uk/cv/* https://denhamparry.co.uk/:splat 301!
+# Old blog posts and pages were permanently removed. Serve 410 Gone so Google
+# drops them from the index cleanly, rather than 301-ing to the homepage
+# (which Google treats as a soft 404). See issue #290.
+/posts/* /404.html 410
+/page/* /404.html 410
+/cv/* /404.html 410


### PR DESCRIPTION
## Summary

Addresses part of #290 (Google Search Console index coverage findings).

Old blog content (`/posts/*`, `/page/*`, `/cv/*`) was permanently removed in a previous cleanup, but `_redirects` 301-redirected every one of those URLs to the homepage. Google treats bulk redirects-to-homepage as **soft 404s**, which is the likely source of the "Page with redirect" (3) and "Crawled – currently not indexed" (3) findings in the Search Console export.

This PR replaces those homepage redirects with **410 Gone** responses (served via the generated `404.html` body), the cleanest signal that the content is permanently gone so Google drops the URLs from its index.

## Changes

- `_redirects`: legacy content paths now return `410` instead of `301 → /`
- Canonical domain consolidation redirects (`*.netlify.com`, `blog.*` → `denhamparry.co.uk`) are **unchanged**

```diff
-https://denhamparry.co.uk/posts/* https://denhamparry.co.uk/:splat 301!
-https://denhamparry.co.uk/page/*  https://denhamparry.co.uk/:splat 301!
-https://denhamparry.co.uk/cv/*    https://denhamparry.co.uk/:splat 301!
+/posts/* /404.html 410
+/page/*  /404.html 410
+/cv/*    /404.html 410
```

## Follow-up (tracked in #290)

This fixes the redirect strategy. The remaining tasks still need the **specific URLs** from Search Console's Pages report:

- [ ] Identify the single "Not found (404)" URL and confirm intent
- [ ] Review the 3 "currently not indexed" URLs once the redirect change has propagated
- [ ] Run "Validate Fix" in Search Console after deploy
- [ ] Re-export and refresh `google_analytics/` to confirm improvement

## Verification

- `layouts/404.html` exists, so Hugo emits `/404.html` for the 410 rule to serve
- pre-commit hooks pass (gitleaks, cspell, prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
