### PR TITLE
feat(ci): auto-assign opened PRs to denhamparry

### DIFF
--- a/.github/workflows/auto-assign-prs.yml
+++ b/.github/workflows/auto-assign-prs.yml
@@ -1,0 +1,25 @@
+name: Auto-assign PRs
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign:
+    name: Assign PR to denhamparry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add assignee
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          curl --silent --show-error --fail -X POST \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/assignees" \
+            -d '{"assignees":["denhamparry"]}'


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/auto-assign-prs.yml`) that automatically assigns every newly opened pull request — including PRs from dependabot and other bots — to @denhamparry, so all open PRs are trackable from the assignee view.

The workflow listens for `pull_request_target` on `opened` and makes a single GitHub API call to add the assignee using the built-in `GITHUB_TOKEN`.

## Security notes

- `pull_request_target` is safe here because the job **never checks out PR code** — it only calls the GitHub REST API with the repository's token.
- Minimal permissions are declared (`issues: write`, `pull-requests: write`).

## Known limitation

PRs created by other workflows using the default `GITHUB_TOKEN` will **not** trigger this workflow — GitHub intentionally prevents `GITHUB_TOKEN`-initiated events from starting new workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)