### PR TITLE
docs(content): fix talks page review findings

### DIFF
--- a/content/talks.md
+++ b/content/talks.md
@@ -1,7 +1,7 @@
 ---
 title: Talks
 date: 2022-04-22T21:00:00+00:00
-reviewed: 2026-06-22
+reviewed: 2026-07-08
 tags: ["talk"]
 author: Lewis Denham-Parry
 showToc: true
@@ -194,13 +194,15 @@ sensitive workloads with strong isolation, strategies for eliminating the
 development-to-production security gap, and emerging patterns in container
 security architecture that prioritize both performance and protection.
 
-### KubeCon EU 2025: Container Runtimes... on Lockdown: The Hidden Costs of
+<!-- markdownlint-disable MD013 -->
 
-Multi-tenant Workloads
+### KubeCon EU 2025: Container Runtimes... on Lockdown: The Hidden Costs of Multi-tenant Workloads
+
+<!-- markdownlint-enable MD013 -->
 
 - Type: Talk
-- [YouTube](https://www.youtube.com/watch?v=I9t7qfOjgbo)
 - Date: 04th April 2025
+- Resources: [Recording](https://www.youtube.com/watch?v=I9t7qfOjgbo)
 
 Container runtimes form the bedrock of Kubernetes, but running diverse workloads
 side-by-side introduces complex security challenges that many teams overlook.
@@ -221,14 +223,16 @@ trade-offs.
 ### The Cloud-Native Club | Project Spotlight: Edera
 
 - Type: Podcast
-- [Youtube](https://www.youtube.com/live/MXdmKViYV9Y?si=jhyyU4EIf4Y1wCe0)
-- Date: 26 Sept 2024
+- Date: 26th September 2024
+- Resources:
+  [Recording](https://www.youtube.com/live/MXdmKViYV9Y?si=jhyyU4EIf4Y1wCe0)
 
 ### OSS North America - The Overconfident Operator Vs the Nefarious Ne'er-Do-Well
 
 - Type: Talk
-- [Open Source Summit North America](https://events.linuxfoundation.org/open-source-summit-north-america/)
 - Date: 17th April 2024
+- Event:
+  [Open Source Summit North America](https://events.linuxfoundation.org/open-source-summit-north-america/)
 
 Ozzie the Overconfident Operator has secured their cluster! They have done it
 all: role-based access control, encryption at rest, TLS…and as they congratulate
@@ -247,8 +251,8 @@ time. There is nothing Nova can do to break… uh-oh. Not again!
 ### KCD Guadalajara 2024 - The Overconfident Operator Vs the Nefarious Ne'er-Do-Well
 
 - Type: Keynote
-- [KCD Guadalajara](https://ccoss.org/)
-- Date: 24-24th February 2024
+- Date: 23-24th February 2024
+- Event: [KCD Guadalajara](https://ccoss.org/)
 
 ## 2023
 
@@ -258,9 +262,9 @@ time. There is nothing Nova can do to break… uh-oh. Not again!
 - Where: [YouTube](https://www.youtube.com/watch?v=Y1rJY_UlLmM)
 - Date: 08th November 2023
 
-### Lighting Talk 2 aka WTF is the Journey
+### Lightning Talk 2 aka WTF is the Journey
 
-- Type: Lighting Talk
+- Type: Lightning Talk
 - Where: [YouTube](https://www.youtube.com/watch?v=dR5T2qNAuCs&t=1s)
 - Date: 17th October 2023
 
@@ -589,7 +593,7 @@ SANS authors:
 
 - Type: Meetup
 - Where: [Cardiff, UK](https://www.meetup.com/AI-Wales/events/283883339/)
-- Date: 03th Mar 2022
+- Date: 03rd March 2022
 
 ### Private Kubernetes Training February 2/2
 
@@ -625,7 +629,7 @@ SANS authors:
 
 - Type: Podcast
 - Where: [cosecast.com](https://cosecast.com/episode-8-kubecon-ctf)
-- Date: 10 January 2022.
+- Date: 10th January 2022
 
 In this episode Steve speaks with the Control Plane Kubernetes security training
 gurus, Lewis Denham-Parry and Andy Martin about their brain-child, the KubeCon
@@ -922,18 +926,19 @@ best to monitor your services to put preventative measures in place.
 - Type: Lightning Talks
 - Where:
   [BlueConf](https://web.archive.org/web/20220521180658/https://blueconf.co.uk/)
-- Date 08th Jun 2019
+- Date: 08th June 2019
 
 ### BlueConf - WTF is Cloud Native
 
 - Type: Talk
 - Where:
   [Cardiff, UK](https://web.archive.org/web/20220521180658/https://blueconf.co.uk/)
-- Date 08th Jun 2019
+- Date: 08th June 2019
 
 ### µCon London 2019 - How do we become Cloud Native?
 
 - Type: Talk
+- Date: 29-31st May 2019
 - Where: London, UK
 
 ### KubeCon EU - How we contributed to the community with no code
@@ -944,7 +949,7 @@ best to monitor your services to put preventative measures in place.
 - Date: 19th May 2019
 - Online: [Barcelona, Spain](https://www.youtube.com/watch?v=4jEASYCaVDo)
 
-This time last year, two people from Wales, United Kingdom decried to bring the
+This time last year, two people from Wales, United Kingdom decided to bring the
 CNCF to their doorstep.
 
 Previously, they were attending international conferences and national meetups
@@ -973,9 +978,11 @@ wide community.
 - Where: [Minnesota, USA](https://pubconf.io/events/2019/minnesota/)
 - Date: 08th May 2019
 
-### NDC Minnesota 2019 - Scaling Microservices with Message Queues, DotNet Core
+<!-- markdownlint-disable MD013 -->
 
-and Kubernetes
+### NDC Minnesota 2019 - Scaling Microservices with Message Queues, DotNet Core and Kubernetes
+
+<!-- markdownlint-enable MD013 -->
 
 - Type: Talk
 - Where: [Minnesota, USA](https://ndcminnesota.com/)
@@ -1022,13 +1029,11 @@ Find out the parallels of mental health to monoliths versus microservices!
 - Type: Talk
 - Where: [London, UK](https://pubconf.io)
 - Date: 1st February 2019
-- Online [YouTube](https://www.youtube.com/watch?v=9NEGZQ3rRQ4)
+- Online: [YouTube](https://www.youtube.com/watch?v=9NEGZQ3rRQ4)
 
 Rapid-fire funny talks, musical acts, and comedy stunts from amazing developers.
 
-### NDC London 2019 - Scaling Microservices with Message queues, .NET and
-
-Kubernetes
+### NDC London 2019 - Scaling Microservices with Message queues, .NET and Kubernetes
 
 - Type: Talk
 - Where: [London, UK](https://ndc-london.com)

--- a/docs/plan/issues/318_page_requires_review_content_talks_md.md
+++ b/docs/plan/issues/318_page_requires_review_content_talks_md.md
@@ -1,0 +1,150 @@
+<!-- cspell:words CCOSS KCD Nefarious Do-Well KubeCon SQUER worktree µCon -->
+
+# GitHub Issue #318: Page requires review: content/talks.md
+
+**Issue:** [#318](https://github.com/denhamparry/website/issues/318) **Status:**
+Complete **Date:** 2026-07-08
+
+## Problem Statement
+
+The `content/talks.md` page has automated review findings after becoming stale.
+The issue identifies broken Markdown headings, several concrete data and typo
+errors, and broader consistency polish opportunities.
+
+### Current Behavior
+
+- `reviewed` is `2026-06-22`.
+- Three long `###` headings are split by a blank line, causing the second half
+  of each title to render as body text.
+- Several talk entries contain typos or malformed dates.
+- The µCon London 2019 entry is missing a date.
+
+### Expected Behavior
+
+- Broken headings render as complete headings.
+- Confirmed data errors and typos from the issue are corrected.
+- `reviewed` is updated to `2026-07-08`.
+- Hugo build and spell-check validation pass.
+
+## Current State Analysis
+
+### Relevant Files
+
+- `content/talks.md` - Talks page content and `reviewed` frontmatter.
+- `docs/plan/issues/318_page_requires_review_content_talks_md.md` - This plan.
+
+### Sources Checked
+
+- GitHub issue #318: issue body lists P1/P2/P3/P4 findings.
+- CCOSS + KCD Guadalajara 2024 final report: confirms the event dates as
+  February 23 and 24, 2024, and lists the Security Showdown session.
+- CCOSS + KCD Guadalajara 2024 prospectus: confirms the event dates as Friday 23
+  and Saturday 24 February 2024.
+- Skills Matter Flickr material describes µCon London 2019 as a three-day
+  conference and is dated 29 May 2019.
+- SQUER's public conference-talk listing includes a µCon London 2019 talk dated
+  31 May 2019.
+
+## Solution Design
+
+### Approach
+
+1. Fix the three broken headings by rejoining each title onto one Markdown
+   heading line.
+2. Correct concrete P2 issues:
+   - KCD Guadalajara date: `23-24th February 2024`.
+   - µCon London 2019 event date range: `29-31st May 2019`.
+   - `Lighting Talk` typo to `Lightning Talk`.
+   - `decried` typo to `decided`.
+   - `03th Mar 2022` to `03rd March 2022`.
+3. Use the corroborated µCon London 2019 event date range rather than inventing
+   an exact session time.
+4. Apply narrow consistency polish for issue-listed malformed field labels:
+   - Change bare current-resource bullets to `Resources:`.
+   - Fix `Youtube` capitalization.
+   - Add missing colons to `Date` and `Online` labels called out by the issue.
+   - Remove the trailing period from `10 January 2022.`.
+5. Update the frontmatter `reviewed` date to `2026-07-08`.
+
+### Rationale
+
+This keeps the PR tightly scoped to confirmed rendering and content-quality
+fixes. The broader P3 title-format and full-page label normalization work would
+touch many entries and is better handled separately if desired.
+
+## Implementation Plan
+
+### Step 1: Update `content/talks.md`
+
+- Change frontmatter:
+
+  ```yaml
+  reviewed: 2026-07-08
+  ```
+
+- Rejoin the three broken headings:
+  - KubeCon EU 2025 container runtimes title.
+  - NDC Minnesota 2019 message queues title.
+  - NDC London 2019 message queues title.
+- Correct confirmed typos, dates, and malformed labels listed in the approach.
+
+### Step 2: Verify
+
+Run:
+
+```bash
+npm run test:hugo
+npm run test:spell
+git diff --check
+```
+
+If local Hugo is unavailable, use the repository's Nix environment or Docker
+fallback documented by the repo.
+
+## Success Criteria
+
+- [x] `content/talks.md` reviewed date is `2026-07-08`.
+- [x] Three broken Markdown headings are fixed.
+- [x] Confirmed P2 data and typo issues are corrected.
+- [x] µCon London 2019 has the corroborated event date range.
+- [x] Hugo build passes.
+- [x] Spell check passes.
+- [x] `git diff --check` passes.
+
+## Validation Results
+
+- `npm run test:hugo` - failed in the plain shell because `hugo` was not on
+  `PATH`.
+- `npm ci` - passed; installed the worktree-local Node dependencies. NPM
+  reported existing peer-dependency warnings and one moderate audit finding.
+- `git submodule update --init --recursive themes/PaperMod` - passed.
+- `npm run test:spell` - passed.
+- `git diff --check` - passed.
+- `nix develop --command bash -lc 'npm run test:hugo'` - passed.
+
+## Branch Review
+
+- Classification: non-code content/documentation changes (`content/talks.md` and
+  this plan).
+- Trail of Bits review skills: skipped - no code-relevant changes.
+- Manual review found no blocking issues after the validation above.
+
+## Files Expected To Change
+
+1. `content/talks.md`
+2. `docs/plan/issues/318_page_requires_review_content_talks_md.md`
+
+## Risks And Open Questions
+
+- The µCon London 2019 source material supports an event range, not the exact
+  session time for the individual talk.
+- P3 asks for broad title and field-label standardization across the page; this
+  plan intentionally limits polish to malformed or issue-called-out labels.
+
+## References
+
+- [GitHub Issue #318](https://github.com/denhamparry/website/issues/318)
+- [CCOSS + KCD Guadalajara 2024 final report](https://www.cncf.io/wp-content/uploads/2024/03/CCOSSKCD-2024-FINAL-REPORT.pdf)
+- [CCOSS + KCD Guadalajara 2024 prospectus](https://ccoss.org/files/CCOSSKCD2024-Prospectus.pdf)
+- [Skills Matter µCon London 2019 photo](https://www.flickr.com/photos/skillsmatter/47957262977)
+- [SQUER conference talks](https://www.squer.io/conferences?f2d91a48_page=4)


### PR DESCRIPTION
## Summary

- Fix broken `content/talks.md` headings that rendered title fragments as body text.
- Correct confirmed talks page data and typo issues, including the KCD Guadalajara date, Lightning Talk typo, µCon London 2019 event date range, malformed date labels, and reviewed date.
- Add the issue plan for #318 with source notes and validation results.

## Validation

- `npm run test:spell` - passed
- `git diff --check` - passed
- `pre-commit run markdownlint --files content/talks.md docs/plan/issues/318_page_requires_review_content_talks_md.md` - passed
- `pre-commit run prettier --files content/talks.md docs/plan/issues/318_page_requires_review_content_talks_md.md` - passed
- `nix develop --command bash -lc 'npm run test:hugo'` - passed
- Commit pre-commit hooks - passed

Plain-shell `npm run test:hugo` initially failed because `hugo` was not on `PATH`; the repo Nix dev shell provides Hugo and passed the test.

## Branch Review

- Classification: non-code content/documentation changes.
- Trail of Bits review skills: skipped - no code-relevant changes.
- Manual review found no blocking issues.

## Follow-up ideas

- Consider a separate full-page normalization pass for all title formats and `Event` / `Resources` labels.
- Verify the optional older CNW Meetup event URLs and whether `searchHidden: true` is still intentional.
- Add a recording/resource link for the 2025 Runtime Rumble "Tag Team Champions" entry if a public URL is available.

Closes #318
