### PR TITLE
chore(website): add codegraph ignore

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in this directory except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore


### PR DESCRIPTION
## Summary

Adds a tracked `.codegraph/.gitignore` so the project can keep a `.codegraph/` directory for local CodeGraph state while preventing transient databases, sockets, PID files, and logs from being committed.

## Validation

- Commit hooks passed during `git commit`.
- `nix shell nixpkgs#hugo -c hugo --gc --minify` passed.
- `npm test` was attempted after `npm ci`; it does not complete in this local session because `hugo` is not installed on PATH for the npm script, and Docker validation could not run because the Docker daemon is not running.

## Notes

The only committed file is `.codegraph/.gitignore`.