### PR TITLE
docs(content): review talks page

### DIFF
--- a/content/talks.md
+++ b/content/talks.md
@@ -1,7 +1,7 @@
 ---
 title: Talks
 date: 2022-04-22T21:00:00+00:00
-reviewed: 2026-07-08
+reviewed: 2026-07-26
 tags: ["talk"]
 author: Lewis Denham-Parry
 showToc: true

--- a/docs/plan/issues/340_page_requires_review_content_talks_md.md
+++ b/docs/plan/issues/340_page_requires_review_content_talks_md.md
@@ -1,0 +1,102 @@
+---
+status: Complete
+issue: 340
+date: 2026-07-26
+---
+
+<!-- cspell:words worktree -->
+
+# GitHub Issue #340: Page requires review: content/talks.md
+
+## Problem Statement
+
+The automated content-maintenance workflow opened
+[#340](https://github.com/denhamparry/website/issues/340) because
+`content/talks.md` had not changed for more than 14 days. The page needs a
+current review marker even when there are no new talks to add.
+
+## Current State
+
+- The frontmatter `reviewed` date is `2026-07-08`.
+- The latest listed talk took place on 14th April 2026.
+- The user confirmed on 26th July 2026 that there are no future talks to add at
+  this time.
+- Previous no-new-talk reviews, including issue #212, updated only the
+  frontmatter review date.
+
+## Acceptance Criteria
+
+- `content/talks.md` records a review date of `2026-07-26`.
+- No speculative future talk entries are added.
+- Existing talk content remains unchanged.
+- Relevant content validation passes.
+
+## Implementation Plan
+
+1. Update the `reviewed` frontmatter field in `content/talks.md` from
+   `2026-07-08` to `2026-07-26`.
+2. Confirm the branch diff contains only the planned review-marker and plan
+   changes.
+3. Run the Hugo build test, spell check, and whitespace validation.
+
+## Files Expected To Change
+
+1. `content/talks.md`
+2. `docs/plan/issues/340_page_requires_review_content_talks_md.md`
+
+## Validation Plan
+
+```bash
+npm run test:hugo
+npm run test:spell
+git diff --check
+```
+
+If Hugo is unavailable in the plain shell, use the repository's Nix development
+environment. Initialize the PaperMod submodule only if the build requires it.
+
+## Risks And Open Questions
+
+- Adding a public "no upcoming talks" placeholder would create user-facing
+  content not requested by the issue and would need later removal. This plan
+  therefore treats the user's statement as review evidence and changes only the
+  review marker.
+- No open questions remain because the user explicitly confirmed that there are
+  no future talks to add.
+
+## Research Validation
+
+- The plan matches issue #340's request to review `content/talks.md`.
+- The user is the authoritative source for whether future talks should be
+  published and confirmed there are none at this time.
+- The expected files match the repository's prior issue-review pattern.
+- The validation commands cover rendering, spelling, and malformed whitespace.
+- Review outcome: approved for implementation.
+
+## Success Criteria
+
+- [x] `content/talks.md` records a review date of `2026-07-26`.
+- [x] No speculative future talk entries were added.
+- [x] Existing talk content is unchanged.
+- [x] Relevant content validation passes.
+
+## Validation Results
+
+- `npm ci` - passed; installed worktree-local test dependencies with existing
+  peer-dependency, deprecation, and audit warnings.
+- `git submodule update --init --recursive themes/PaperMod` - passed.
+- `nix develop --command bash -lc 'npm run test:hugo'` - passed all nine Hugo
+  build checks, including talks-page generation and HTML validation.
+- `npm run test:spell` - initially failed on `worktree` in this plan, then
+  passed after adding the local cspell word annotation; 37 files checked with no
+  remaining issues.
+- `git diff --check` - passed.
+
+## Branch Review
+
+- Classification: non-code content/documentation changes (`content/talks.md` and
+  this plan).
+- Trail of Bits review skills: skipped - no code-relevant changes.
+- Manual review confirmed that the content diff changes only the frontmatter
+  review date and introduces no speculative talk content.
+- No blocking findings or non-blocking follow-up ideas were identified.


### PR DESCRIPTION
## Summary

- update the talks page review date to 26 July 2026
- leave the existing talk list unchanged because there are no future talks to add at this time
- add the reviewed implementation plan for issue #340

## Validation

- `nix develop --command bash -lc 'npm run test:hugo'`
- `npm run test:spell`
- `git diff --check`
- pre-commit hooks, including markdownlint, cspell, Prettier, and secret detection

## Branch review

- Classification: non-code content/documentation changes
- Trail of Bits review skills: skipped - no code-relevant changes
- Manual review: no blocking findings or follow-up ideas

Closes #340
