### PR TITLE
docs(content): review search page

### DIFF
--- a/content/search.md
+++ b/content/search.md
@@ -3,4 +3,5 @@ title: Search
 layout: search
 summary: Search this site
 placeholder: Search
+reviewed: 2026-07-26
 ---

--- a/docs/plan/issues/341_page_requires_review_content_search_md.md
+++ b/docs/plan/issues/341_page_requires_review_content_search_md.md
@@ -1,0 +1,118 @@
+---
+status: Complete
+issue: 341
+date: 2026-07-26
+---
+
+<!-- cspell:words PaperMod worktree -->
+
+# GitHub Issue #341: Page requires review: content/search.md
+
+## Problem
+
+GitHub issue [#341](https://github.com/denhamparry/website/issues/341) reports
+that `content/search.md` requires review. The page was introduced on 2026-07-08
+and contains the minimal frontmatter needed to select PaperMod's search layout,
+but it does not record when its content was last reviewed.
+
+## Acceptance Criteria
+
+- [x] `content/search.md` records a review date of `2026-07-26`.
+- [x] The existing search title, layout, summary, and placeholder remain
+      unchanged.
+- [x] `/search/` remains reachable from the site navigation.
+- [x] Searching for `Talks` continues to return the Talks page.
+- [x] Repository validation passes.
+
+## Implementation Plan
+
+1. Add a `reviewed` field to the search page frontmatter using today's local
+   date.
+2. Build and test the site, including the existing browser-backed search
+   coverage.
+3. Confirm the branch diff contains only the review marker and this plan.
+4. Record validation and branch-review results in this plan.
+
+## Files Expected To Change
+
+1. `content/search.md`
+2. `docs/plan/issues/341_page_requires_review_content_search_md.md`
+
+## Validation
+
+Run:
+
+```bash
+git diff --check
+npm test
+npm run test:spell
+pre-commit run --all-files
+```
+
+Also inspect the generated or served `/search/` page and confirm its search
+input returns the Talks page.
+
+## Risks And Open Questions
+
+- The scheduled stale-page workflow uses the file's most recent Git commit,
+  rather than the `reviewed` value. This change still satisfies that mechanism
+  because it commits the completed review, while the frontmatter makes the
+  review date explicit for future maintainers.
+- Arbitrary Hugo frontmatter fields are inert unless a template reads them, so
+  adding `reviewed` must not alter rendering or search behaviour.
+
+## Research Review
+
+- Iteration 1: The plan matches issue #341's review request and the repository's
+  existing stale-page mechanism. The search page's four existing fields match
+  the pinned PaperMod search setup, and focused functional tests already cover
+  navigation to `/search/` and a `Talks` result.
+- The expected file list is complete: the content review needs only an inert
+  frontmatter marker plus this workflow plan. No layout, theme, configuration,
+  or test changes are justified.
+- The validation exercises Hugo rendering, browser-backed search behaviour,
+  accessibility, spelling, and repository hooks. No blocking gaps remain.
+
+## Implementation Notes
+
+- Added `reviewed: 2026-07-26` to `content/search.md`.
+- Preserved the existing title, PaperMod search layout, summary, and placeholder
+  exactly.
+- No tests, templates, theme files, or site configuration needed changes because
+  the existing functional suite directly covers the reviewed behaviour.
+
+## Validation Results
+
+- `git submodule update --init --recursive themes/PaperMod` - passed.
+- `npm ci` - passed; npm reported existing peer-dependency/deprecation warnings
+  and two high-severity audit findings unrelated to this documentation change.
+- `nix develop --command bash -lc 'npm test'` with the local Hugo server
+  running - passed:
+  - 9 Hugo build checks.
+  - 20 functional tests across two suites.
+  - 100 accessibility checks with zero violations.
+- Rendered `/search/` inspection - passed; the search input and bundled search
+  script are present.
+- Rendered `index.json` inspection - passed; it includes the Talks page.
+- `npm run test:spell` - passed, 39 files checked with zero issues.
+- `pre-commit run --all-files` - passed all hooks.
+- `git diff --check` - passed.
+
+## Branch Review
+
+- Classification: non-code. The branch changes one inert content-frontmatter
+  review marker and this Markdown plan.
+- Repo-local `docs/pre-pr-branch-review.md`: not present.
+- Trail of Bits review skills: skipped because there are no code-relevant
+  changes.
+- Manual differential review found no blocking issues. The reviewed search
+  metadata remains intact, arbitrary frontmatter does not affect the selected
+  layout, existing browser-backed tests cover navigation and results, and no
+  theme file is modified.
+- Follow-up ideas: none.
+
+## Outcome
+
+Issue #341 is ready for a pull request. The search page records its completed
+review on 2026-07-26, and the existing search page, Talks result, and
+accessibility behaviour remain verified.


### PR DESCRIPTION
## Summary

- record the 2026-07-26 review date in the search page frontmatter
- preserve the existing PaperMod search title, layout, summary, and placeholder
- document the issue analysis, scope, and verification results

## Validation

- `nix develop --command bash -lc 'npm test'`
  - 9 Hugo build checks passed
  - 20 functional tests passed
  - 100 accessibility checks passed with zero violations
- rendered `/search/` contains the search input and bundled search script
- rendered `index.json` contains the Talks page
- `npm run test:spell` passed with 39 files and zero issues
- `pre-commit run --all-files` passed
- `git diff --check` passed

## Branch review

- Classification: non-code content frontmatter and workflow documentation
- Trail of Bits review skills: skipped because there are no code-relevant changes
- Manual differential review found no blocking issues
- Follow-up ideas: none

Closes #341
