### PR TITLE
fix(tests): replace chalk with node style text

### DIFF
--- a/docs/plan/issues/351_replace_direct_chalk_usage_with_node_styletext.md
+++ b/docs/plan/issues/351_replace_direct_chalk_usage_with_node_styletext.md
@@ -1,0 +1,170 @@
+---
+status: Complete
+issue: 351
+date: 2026-08-01
+---
+
+<!-- cspell:words styleText worktree -->
+
+# GitHub Issue #351: Replace direct Chalk usage with Node styleText
+
+## Problem Statement
+
+Dependabot PR [#349](https://github.com/denhamparry/website/pull/349) upgrades
+Chalk from 4.1.2 to 6.0.0, but Chalk 5 and later are ESM-only. The repository's
+Hugo and accessibility test scripts are CommonJS, so Node 22 returns Chalk's
+module namespace from `require("chalk")` and calls such as `chalk.blue(...)`
+fail before the tests run.
+
+## Current State
+
+- `tests/hugo/test-hugo-build.js` imports Chalk and uses six colour or emphasis
+  styles across its build checks and summary output.
+- `tests/accessibility/test-accessibility.js` imports Chalk and uses the same
+  styles throughout its page and accessibility reporting.
+- `package.json` declares Chalk 4.1.2 as a direct development dependency and
+  `package-lock.json` records that root dependency.
+- CI and `.nvmrc` target Node 22, whose standard `node:util` module provides
+  CommonJS-compatible `styleText(format, text)` with all six required formats.
+- PR #349 remains open and failing as of 2026-08-01. This replacement makes its
+  direct Chalk upgrade unnecessary; the workflow must leave that PR for manual
+  closure because automatic PR closure is out of scope.
+
+## Acceptance Criteria
+
+- [x] `npm run test:hugo` passes on Node 22 without importing Chalk.
+- [x] `npm run test:accessibility` passes and retains styled terminal output.
+- [x] The complete `npm test` suite passes with a running Hugo server.
+- [x] Chalk is removed from direct development dependencies in `package.json`
+      and from the root dependency set in `package-lock.json`.
+- [x] Any remaining Chalk entries in the lockfile are demonstrably transitive,
+      not used directly by these test scripts.
+- [x] PR #349 is identified as superseded for the user to close manually after
+      reviewing this replacement PR.
+
+## Solution Design
+
+Use the issue's recommended standard-library approach:
+
+1. Import `styleText` from `node:util` in both CommonJS scripts.
+2. Replace each `chalk.<format>(text)` call with `styleText("<format>", text)`
+   for `blue`, `red`, `green`, `yellow`, `gray`, and `bold`.
+3. Convert the one multi-argument Chalk call into one interpolated string,
+   because `styleText` accepts a single text argument.
+4. Remove the direct Chalk dependency with npm so both dependency manifests stay
+   synchronized.
+
+This keeps the scripts CommonJS, avoids package-level module changes, and
+removes the direct dependency that caused the compatibility failure.
+
+## Implementation Plan
+
+1. Replace direct Chalk imports and calls in the Hugo build test script.
+2. Replace direct Chalk imports and calls in the accessibility test script.
+3. Remove the direct Chalk development dependency and refresh the lockfile.
+4. Confirm planned and actual files match, then run the repository validation
+   and review the differential against `origin/main`.
+
+## Files Expected To Change
+
+1. `tests/hugo/test-hugo-build.js`
+2. `tests/accessibility/test-accessibility.js`
+3. `package.json`
+4. `package-lock.json`
+5. `docs/plan/issues/351_replace_direct_chalk_usage_with_node_styletext.md`
+
+## Validation Plan
+
+```bash
+npm ci
+npm run test:hugo
+npm test
+npm run test:spell
+git diff --check
+pre-commit run --all-files
+```
+
+Run the complete test suite inside the repository's Nix development environment
+when the plain shell lacks Hugo. Start Hugo as a background process for the
+functional and accessibility phases. Use `FORCE_COLOR=1` in a focused invocation
+to confirm `styleText` emits ANSI styling, and inspect `npm ls chalk` plus the
+lockfile root package to distinguish direct from transitive Chalk dependencies.
+
+## Risks And Open Questions
+
+- `styleText` validates terminal colour support by default, so CI logs without a
+  TTY may be uncoloured. That matches the standard library's intended behaviour;
+  a forced-colour focused check verifies the formatting path.
+- Local Node is newer than CI's Node 22. The full GitHub Actions run on the PR
+  is the final Node 22 compatibility gate.
+- Removing the direct dependency will not remove every transitive Chalk package
+  from `package-lock.json`; unrelated test tools still depend on Chalk. The root
+  dependency entry and application imports are the relevant scope.
+- No implementation question remains open.
+
+## Research Validation
+
+- Iteration 1 confirmed the plan matches every issue acceptance criterion that
+  can be completed without merging or closing another pull request.
+- Node 22.23.1 was invoked directly through Nix and successfully loaded
+  `styleText` through `require("node:util")`; all six planned formats emitted
+  ANSI sequences with stream validation disabled for the focused check.
+- The Node 22 documentation confirms `styleText(format, text[, options])` was
+  added before Node 22 and supports CommonJS plus the required formats (checked
+  2026-08-01 at
+  `https://nodejs.org/download/release/latest-jod/docs/api/util.html#utilstyletextformat-text-options`).
+- The two scripts contain all direct Chalk imports and application call sites;
+  repository-wide search found no other direct code usage.
+- `package.json`, its lockfile, both scripts, and this lifecycle plan are the
+  complete expected file set. The theme, Hugo content, Jest configuration, and
+  CI workflow do not require edits.
+- PR #349 is still open and failing as of 2026-08-01. Creating a replacement PR
+  with `Closes #351` is safe, while closing #349 remains an explicit manual
+  follow-up under the workflow's no-close rule.
+- Review outcome: approved for implementation.
+
+## Implementation Notes
+
+- Replaced both `require("chalk")` imports with a destructured CommonJS import
+  of `styleText` from `node:util`.
+- Mapped every existing colour and emphasis call to the corresponding
+  `styleText` format without changing test control flow or result handling.
+- Converted the Hugo build failure's two Chalk arguments into one interpolated
+  string so the visible message remains `Build failed: <message>`.
+- Removed Chalk from the root development dependencies in both npm manifests.
+  The lockfile's remaining Chalk packages belong to Jest, cspell, and Linkinator
+  dependency trees.
+
+## Validation Results
+
+- `nix shell nixpkgs#nodejs_22 -c node --version` - passed with Node 22.23.1.
+- Focused Node 22 format check - all six `styleText` formats emitted ANSI
+  sequences with stream validation disabled.
+- `nix shell nixpkgs#nodejs_22 -c npm ci` - passed with existing Babel peer
+  warnings, deprecation notices, and two high-severity audit findings unrelated
+  to this dependency removal.
+- `nix shell nixpkgs#nodejs_22 nixpkgs#hugo -c npm test` - passed after final
+  formatting: nine Hugo checks, 20 functional tests, and 100 accessibility
+  checks with zero violations.
+- Forced-colour `npm run test:hugo` invocation - passed and contained ANSI
+  styling from the migrated script.
+- `npm ls chalk --all` - confirmed all remaining Chalk packages are transitive
+  dependencies of Jest, cspell, or Linkinator.
+- `npm run test:spell` - passed all 40 checked files.
+- `pre-commit run --all-files` - first pass formatted the accessibility script;
+  the second pass passed every hook, including gitleaks, cspell, and Prettier.
+- `git diff --check` - passed.
+
+## Branch Review
+
+- Classification: code-relevant JavaScript test scripts and npm dependency
+  manifests, plus this plan.
+- Repo-local `docs/pre-pr-branch-review.md`: not present.
+- `differential-review` and Trail of Bits specialist skills: unavailable in this
+  session; performed the workflow reference's manual differential-review
+  fallback against `origin/main`.
+- Manual review checked CommonJS compatibility, format-name support, all Chalk
+  call sites, the multi-argument output conversion, manifest-lockfile
+  consistency, transitive dependencies, unchanged test control flow, final
+  formatting, and planned-file scope.
+- No blocking findings or non-blocking follow-up ideas were identified.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@babel/preset-env": "8.0.2",
         "axios": "1.18.1",
         "babel-jest": "30.4.1",
-        "chalk": "4.1.2",
         "cspell": "10.0.1",
         "jest": "30.4.2",
         "linkinator": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@babel/preset-env": "8.0.2",
     "axios": "1.18.1",
     "babel-jest": "30.4.1",
-    "chalk": "4.1.2",
     "cspell": "10.0.1",
     "jest": "30.4.2",
     "linkinator": "8.0.2",

--- a/tests/accessibility/test-accessibility.js
+++ b/tests/accessibility/test-accessibility.js
@@ -2,9 +2,9 @@
 
 const { AxePuppeteer } = require("@axe-core/puppeteer");
 const puppeteer = require("puppeteer");
-const chalk = require("chalk");
+const { styleText } = require("node:util");
 
-console.log(chalk.blue("♿ Running Accessibility Tests...\n"));
+console.log(styleText("blue", "♿ Running Accessibility Tests...\n"));
 
 const pages = [
   { name: "Homepage", url: "http://localhost:1313" },
@@ -25,8 +25,8 @@ async function runAccessibilityTests() {
   let totalPasses = 0;
 
   for (const pageInfo of pages) {
-    console.log(chalk.bold(`\nTesting: ${pageInfo.name}`));
-    console.log(chalk.gray(`URL: ${pageInfo.url}`));
+    console.log(styleText("bold", `\nTesting: ${pageInfo.name}`));
+    console.log(styleText("gray", `URL: ${pageInfo.url}`));
 
     try {
       const page = await browser.newPage();
@@ -40,35 +40,45 @@ async function runAccessibilityTests() {
       // Report violations
       if (results.violations.length > 0) {
         console.log(
-          chalk.red(
+          styleText(
+            "red",
             `\n  ❌ Found ${results.violations.length} accessibility violations:`,
           ),
         );
 
         results.violations.forEach((violation, index) => {
-          console.log(chalk.red(`\n  ${index + 1}. ${violation.description}`));
-          console.log(chalk.yellow(`     Impact: ${violation.impact}`));
-          console.log(chalk.gray(`     Help: ${violation.help}`));
-          console.log(chalk.gray(`     More info: ${violation.helpUrl}`));
+          console.log(
+            styleText("red", `\n  ${index + 1}. ${violation.description}`),
+          );
+          console.log(styleText("yellow", `     Impact: ${violation.impact}`));
+          console.log(styleText("gray", `     Help: ${violation.help}`));
+          console.log(
+            styleText("gray", `     More info: ${violation.helpUrl}`),
+          );
 
           violation.nodes.forEach((node, nodeIndex) => {
-            console.log(chalk.gray(`\n     Element ${nodeIndex + 1}:`));
-            console.log(chalk.gray(`       ${node.html}`));
+            console.log(styleText("gray", `\n     Element ${nodeIndex + 1}:`));
+            console.log(styleText("gray", `       ${node.html}`));
             if (node.failureSummary) {
-              console.log(chalk.gray(`       Issue: ${node.failureSummary}`));
+              console.log(
+                styleText("gray", `       Issue: ${node.failureSummary}`),
+              );
             }
           });
         });
 
         totalViolations += results.violations.length;
       } else {
-        console.log(chalk.green("  ✅ No accessibility violations found!"));
+        console.log(
+          styleText("green", "  ✅ No accessibility violations found!"),
+        );
       }
 
       // Report passes
       if (results.passes.length > 0) {
         console.log(
-          chalk.green(
+          styleText(
+            "green",
             `  ✓ Passed ${results.passes.length} accessibility checks`,
           ),
         );
@@ -85,14 +95,16 @@ async function runAccessibilityTests() {
 
       if (criticalViolations.length > 0) {
         console.log(
-          chalk.red(
+          styleText(
+            "red",
             `\n  ⚠️  ${criticalViolations.length} CRITICAL violations found!`,
           ),
         );
       }
       if (seriousViolations.length > 0) {
         console.log(
-          chalk.yellow(
+          styleText(
+            "yellow",
             `  ⚠️  ${seriousViolations.length} SERIOUS violations found!`,
           ),
         );
@@ -101,7 +113,10 @@ async function runAccessibilityTests() {
       await page.close();
     } catch (error) {
       console.log(
-        chalk.red(`\n  Error testing ${pageInfo.name}: ${error.message}`),
+        styleText(
+          "red",
+          `\n  Error testing ${pageInfo.name}: ${error.message}`,
+        ),
       );
       totalViolations++;
     }
@@ -110,31 +125,38 @@ async function runAccessibilityTests() {
   await browser.close();
 
   // Summary
-  console.log(chalk.bold("\n\n📊 Accessibility Test Summary:"));
-  console.log(chalk.green(`  Total checks passed: ${totalPasses}`));
-  console.log(chalk.red(`  Total violations: ${totalViolations}`));
+  console.log(styleText("bold", "\n\n📊 Accessibility Test Summary:"));
+  console.log(styleText("green", `  Total checks passed: ${totalPasses}`));
+  console.log(styleText("red", `  Total violations: ${totalViolations}`));
 
   if (totalViolations === 0) {
     console.log(
-      chalk.green(
+      styleText(
+        "green",
         "\n✅ All accessibility tests passed! Your site is accessible.",
       ),
     );
     process.exit(0);
   } else {
     console.log(
-      chalk.red(
+      styleText(
+        "red",
         `\n❌ Found ${totalViolations} accessibility issues that need to be fixed.`,
       ),
     );
-    console.log(chalk.yellow("\n💡 Tips for fixing accessibility issues:"));
-    console.log(chalk.gray("  - Ensure all images have alt text"));
-    console.log(chalk.gray("  - Use semantic HTML elements"));
-    console.log(chalk.gray("  - Ensure sufficient colour contrast"));
     console.log(
-      chalk.gray("  - Make all interactive elements keyboard accessible"),
+      styleText("yellow", "\n💡 Tips for fixing accessibility issues:"),
     );
-    console.log(chalk.gray("  - Use ARIA labels where appropriate"));
+    console.log(styleText("gray", "  - Ensure all images have alt text"));
+    console.log(styleText("gray", "  - Use semantic HTML elements"));
+    console.log(styleText("gray", "  - Ensure sufficient colour contrast"));
+    console.log(
+      styleText(
+        "gray",
+        "  - Make all interactive elements keyboard accessible",
+      ),
+    );
+    console.log(styleText("gray", "  - Use ARIA labels where appropriate"));
     process.exit(1);
   }
 }
@@ -148,7 +170,9 @@ http
     }
   })
   .on("error", () => {
-    console.log(chalk.red("❌ Hugo server is not running!"));
-    console.log(chalk.yellow("Please start the Hugo server with: hugo server"));
+    console.log(styleText("red", "❌ Hugo server is not running!"));
+    console.log(
+      styleText("yellow", "Please start the Hugo server with: hugo server"),
+    );
     process.exit(1);
   });

--- a/tests/hugo/test-hugo-build.js
+++ b/tests/hugo/test-hugo-build.js
@@ -3,16 +3,16 @@
 const { execSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
-const chalk = require("chalk");
+const { styleText } = require("node:util");
 
-console.log(chalk.blue("🔨 Running Hugo Build Tests...\n"));
+console.log(styleText("blue", "🔨 Running Hugo Build Tests...\n"));
 
 const tests = [
   {
     name: "Hugo Version Check",
     test: () => {
       const version = execSync("hugo version", { encoding: "utf8" });
-      console.log(chalk.gray(`Hugo version: ${version.trim()}`));
+      console.log(styleText("gray", `Hugo version: ${version.trim()}`));
       return version.includes("hugo");
     },
   },
@@ -23,7 +23,7 @@ const tests = [
         execSync("hugo --gc --minify", { stdio: "inherit" });
         return true;
       } catch (error) {
-        console.error(chalk.red("Build failed:", error.message));
+        console.error(styleText("red", `Build failed: ${error.message}`));
         return false;
       }
     },
@@ -86,10 +86,13 @@ const tests = [
         indexContent.includes("<body>") || indexContent.includes("<body ");
 
       if (!hasDoctype)
-        console.error(chalk.yellow("  Missing DOCTYPE declaration"));
-      if (!hasHtmlTag) console.error(chalk.yellow("  Missing <html> tag"));
-      if (!hasHeadTag) console.error(chalk.yellow("  Missing <head> tag"));
-      if (!hasBodyTag) console.error(chalk.yellow("  Missing <body> tag"));
+        console.error(styleText("yellow", "  Missing DOCTYPE declaration"));
+      if (!hasHtmlTag)
+        console.error(styleText("yellow", "  Missing <html> tag"));
+      if (!hasHeadTag)
+        console.error(styleText("yellow", "  Missing <head> tag"));
+      if (!hasBodyTag)
+        console.error(styleText("yellow", "  Missing <body> tag"));
 
       return hasDoctype && hasHtmlTag && hasHeadTag && hasBodyTag;
     },
@@ -102,26 +105,26 @@ let failed = 0;
 tests.forEach(({ name, test }) => {
   try {
     if (test()) {
-      console.log(chalk.green(`✓ ${name}`));
+      console.log(styleText("green", `✓ ${name}`));
       passed++;
     } else {
-      console.log(chalk.red(`✗ ${name}`));
+      console.log(styleText("red", `✗ ${name}`));
       failed++;
     }
   } catch (error) {
-    console.log(chalk.red(`✗ ${name}`));
-    console.error(chalk.red(`  Error: ${error.message}`));
+    console.log(styleText("red", `✗ ${name}`));
+    console.error(styleText("red", `  Error: ${error.message}`));
     failed++;
   }
 });
 
-console.log("\n" + chalk.bold("Test Results:"));
-console.log(chalk.green(`  Passed: ${passed}`));
-console.log(chalk.red(`  Failed: ${failed}`));
+console.log("\n" + styleText("bold", "Test Results:"));
+console.log(styleText("green", `  Passed: ${passed}`));
+console.log(styleText("red", `  Failed: ${failed}`));
 
 if (failed > 0) {
-  console.log("\n" + chalk.red("❌ Hugo build tests failed!"));
+  console.log("\n" + styleText("red", "❌ Hugo build tests failed!"));
   process.exit(1);
 } else {
-  console.log("\n" + chalk.green("✅ All Hugo build tests passed!"));
+  console.log("\n" + styleText("green", "✅ All Hugo build tests passed!"));
 }


### PR DESCRIPTION
## Summary

- replace direct Chalk calls in the CommonJS Hugo and accessibility test scripts with Node 22's built-in `styleText`
- remove Chalk from the root development dependencies while retaining unrelated transitive copies
- preserve the existing coloured and emphasized test output without converting the repository to ESM

## Validation

- `nix shell nixpkgs#nodejs_22 -c npm ci`
- `nix shell nixpkgs#nodejs_22 nixpkgs#hugo -c npm test` (9 Hugo checks, 20 functional tests, 100 accessibility checks)
- forced-colour Hugo test output contains ANSI styling
- `npm ls chalk --all` confirms remaining copies are transitive
- `npm run test:spell`
- `pre-commit run --all-files`
- `git diff --check`

## Branch review

- Classification: code-relevant JavaScript test scripts and npm dependency manifests, plus the implementation plan.
- Repo-local `docs/pre-pr-branch-review.md`: not present.
- `differential-review` and Trail of Bits specialist skills: unavailable in this session; completed the workflow's manual differential-review fallback against `origin/main`.
- Result: no blocking findings or non-blocking follow-up ideas.

## Related pull request

Dependabot PR #349 is superseded by removing the direct Chalk dependency. It should be closed manually after this replacement is reviewed; this workflow has left it open.

Closes #351
