### PR TITLE
docs(content): add kcd uk 2026 talk

### DIFF
--- a/content/search.md
+++ b/content/search.md
@@ -3,5 +3,5 @@ title: Search
 layout: search
 summary: Search this site
 placeholder: Search
-reviewed: 2026-08-20
+reviewed: 2026-09-05
 ---

--- a/content/talks.md
+++ b/content/talks.md
@@ -1,7 +1,7 @@
 ---
 title: Talks
 date: 2022-04-22T21:00:00+00:00
-reviewed: 2026-08-20
+reviewed: 2026-09-05
 tags: ["talk"]
 author: Lewis Denham-Parry
 showToc: true
@@ -26,6 +26,33 @@ menu:
 ---
 
 ## 2026
+
+<!-- markdownlint-disable MD013 -->
+
+### KCD UK Edinburgh 2026 - GPUs have the Power! Lessons learned from DPS and MaxLPS
+
+<!-- markdownlint-enable MD013 -->
+
+- Type: Talk
+- Date: 19th October 2026
+- Event: [KCD UK Edinburgh 2026](https://ckranz.github.io/kcduk/)
+
+AI platforms promise elastic compute, but GPU clusters are increasingly
+constrained by power: what can run, when, and at what priority. This talk uses
+DPS/MaxLPS, NVIDIA's open source power-management project, as deployed within
+Nscale, as a practical case study in making Kubernetes aware of the physical
+limits behind AI workloads.
+
+We will unpack what DPS is, why MaxLPS matters, and how the pattern connects
+Kubernetes scheduling, telemetry, policy, and infrastructure control. The goal
+is not a product pitch; it is a Kubernetes operator's view of the hard
+questions: how do you model power as a shared resource, how do AI workloads
+express urgency, where should control loops live, and what safety gates are
+needed before software adjusts hardware behaviour?
+
+Attendees will leave with a mental model for power-aware cloud-native platforms,
+the risks of closed-loop automation, and lessons that apply even if they never
+run DPS themselves.
 
 <!-- markdownlint-disable MD013 -->
 

--- a/docs/plan/issues/388_389_review_talks_and_search.md
+++ b/docs/plan/issues/388_389_review_talks_and_search.md
@@ -1,0 +1,163 @@
+---
+status: Complete
+issues:
+  - 388
+  - 389
+date: 2026-09-05
+---
+
+<!-- cspell:words MaxLPS Pentland Sessionize -->
+
+# GitHub Issues #388 and #389: Review Talks and Search Pages
+
+## Problem
+
+GitHub issues [#388](https://github.com/denhamparry/website/issues/388) and
+[#389](https://github.com/denhamparry/website/issues/389) report that
+`content/talks.md` and `content/search.md` require review. Lewis also asked for
+his accepted KCD UK Edinburgh 2026 session to be added to the Talks page using
+the published conference schedule.
+
+## Source Snapshot
+
+- Both issues were fetched on 2026-09-05. They were open, assigned to Lewis,
+  labelled `documentation` and `help wanted`, and had no comments. Their bodies
+  contain only “This page requires review”.
+- The KCD UK 2026 schedule at <https://ckranz.github.io/kcduk/> loads live data
+  from Sessionize. The data was fetched on 2026-09-05 and lists Lewis
+  Denham-Parry's accepted, confirmed talk, “GPUs have the Power! Lessons learned
+  from DPS and MaxLPS”, from 11:15 to 11:45 on 2026-10-19 in Pentland West.
+- The schedule supplies the talk abstract. Its `liveUrl` and `recordingUrl` are
+  null, and the speaker entry supplies no additional links, so no resource link
+  is currently available.
+- `content/search.md` still selects PaperMod's `search` layout and retains the
+  expected title, summary, placeholder, and navigation behaviour.
+
+## Acceptance Criteria And Traceability
+
+| Source item                                  | Disposition               | Evidence target                                                          |
+| -------------------------------------------- | ------------------------- | ------------------------------------------------------------------------ |
+| Review `content/talks.md` (#388)             | Implement in this PR      | Set `reviewed` to `2026-09-05` after checking the page                   |
+| Add the requested KCD UK Edinburgh 2026 talk | Implement in this PR      | Add the sourced title, date, event link, and abstract at the top of 2026 |
+| Avoid unsupported resources                  | Implement in this PR      | Omit `Resources` until the schedule publishes one                        |
+| Review `content/search.md` (#389)            | Implement in this PR      | Preserve its search metadata and set `reviewed` to `2026-09-05`          |
+| Keep search functionality working            | Validate without new code | Existing functional coverage must still find the Talks page              |
+| Close both issues after the updates          | Implement in PR metadata  | Use `Closes #388` and `Closes #389`; do not close either manually        |
+| Deployment or merge                          | Out of scope              | Leave the PR open for user-managed review and merge                      |
+
+## Implementation Plan
+
+1. Update the Talks page review date and add the sourced KCD UK 2026 entry in
+   reverse chronological order.
+2. Update only the Search page's inert review marker after confirming its
+   PaperMod search configuration remains correct.
+3. Compare the actual branch diff with the planned three-file scope.
+4. Run the full site, functional, accessibility, spelling, link, Markdown-fence,
+   whitespace, and staged pre-commit checks.
+5. Re-fetch both issues for branch review, then open one PR with automatic
+   closing linkage for both explicitly grouped review issues.
+
+## Files Expected To Change
+
+1. `content/talks.md`
+2. `content/search.md`
+3. `docs/plan/issues/388_389_review_talks_and_search.md`
+
+## Validation Plan
+
+```bash
+nix develop --command bash -lc 'npm test'
+npm run test:links
+npm run test:spell
+git diff --check
+pre-commit run --all-files
+```
+
+Also assert that the rendered Talks page contains the new title and date, the
+rendered Search page still includes its search input, and the generated search
+index still includes the Talks page. Every executable shell fence in changed
+Markdown must pass syntax validation.
+
+## Risks And Open Questions
+
+- The schedule is dynamic external data. The plan records the fetch date and
+  copies only the published title, date, event identity, and abstract required
+  for the website entry.
+- No resource link is published. Adding a guessed slide or recording location
+  would create an unsupported claim, so the entry deliberately omits it.
+- The event begins on 19 October and spans two days, but the published session
+  itself starts on 19 October; the talk entry therefore uses the session date.
+- This is a low-risk content-only change. No deployment, credential, runtime, or
+  security mutation is required.
+
+## Research Review
+
+- Iteration 1 confirmed that both live issues are stale-page review reminders
+  with no hidden comment requirements and that the user explicitly grouped them.
+- The exact Sessionize speaker ID maps to one accepted and confirmed session;
+  its room ID maps to Pentland West, and its time and abstract are present in
+  the same source payload.
+- Prior review issues #340 and #341 establish the repository convention of
+  preserving page behaviour while refreshing `reviewed`. The existing full suite
+  directly covers Talks generation, navigation, search results, and
+  accessibility.
+- Existing talk entries are reverse chronological and permit entries without a
+  `Resources` field. The expected file list is complete, and no theme or test
+  change is justified.
+- Review outcome: approved for implementation with no blocking open question.
+
+## Implementation Notes
+
+- Added the sourced KCD UK Edinburgh 2026 session above the earlier 2026 talks,
+  preserving reverse chronological order.
+- Included the published title, session date, schedule link, and full abstract.
+  No unsupported resources field, time, or room metadata was added.
+- Updated both page review markers to `2026-09-05` without changing the Search
+  page's title, layout, summary, or placeholder.
+
+## Validation Results
+
+- `git submodule update --init --recursive themes/PaperMod` - passed at the
+  repository-pinned PaperMod commit.
+- `npm ci` - passed: 451 packages installed and zero vulnerabilities reported.
+- Server-backed `nix develop --command bash -lc 'npm test'` - passed all nine
+  Hugo checks, 20 functional tests, and 100 accessibility checks with zero
+  violations.
+- Rendered-content assertions - passed: the Talks HTML contains the new title,
+  event, and date; the Search HTML contains its search input; `index.json`
+  contains the Talks page and new session text.
+- `npm run test:links` - passed: 12 rendered-site links scanned with zero
+  errors.
+- CI-equivalent `lychee` validation - passed: 90 links checked, 86 unique, 90
+  successful, zero errors, and 39 redirects.
+- `npm run test:spell` - passed: 48 files checked with zero spelling issues.
+- Complete changed-Markdown shell-fence validation - passed: the two content
+  pages contain no executable fences, and this plan's Bash fence passes
+  `bash -n`.
+- `git diff --check` - passed.
+- Staged `pre-commit run --all-files` - the first run passed every hook except
+  Prettier, which reformatted the new content and plan. After selectively
+  restaging the three intended files, the second run passed every hook without
+  further changes.
+
+## Branch Review
+
+- Both live issues were re-fetched on 2026-09-05 and remained open, unchanged,
+  and without comments.
+- Classification: non-code content plus an implementation plan.
+- Repo-local `docs/pre-pr-branch-review.md`: not present.
+- Trail of Bits review skills: skipped because there are no code-relevant
+  changes.
+- Manual differential review confirmed that the sourced talk is placed in the
+  correct year and order, its public details match the schedule payload, both
+  review dates are current, and the Search metadata is otherwise unchanged.
+- A related-content sweep found earlier KCD UK entries but no duplicate 2026
+  session. Blocking findings: none. Follow-up ideas: none.
+
+## Outcome
+
+Both stale pages record their 2026-09-05 review, and the Talks page publishes
+the sourced KCD UK Edinburgh 2026 session without inventing unavailable
+resources. All local content, site, search, accessibility, spelling, link,
+shell-fence, diff, and pre-commit checks pass. The change is ready for commit,
+an open pull request, and independent post-PR verification.


### PR DESCRIPTION
## Summary

- add Lewis's published KCD UK Edinburgh 2026 session to the Talks page
- refresh the Talks and Search page review dates after checking both pages
- record the combined implementation and validation plan for issues #388 and #389

The talk title, date, event link, and abstract come from the [KCD UK 2026 schedule](https://ckranz.github.io/kcduk/). No resources link is included because the published schedule currently provides neither slides nor a recording.

## Validation

- `npm ci` (451 packages, zero reported vulnerabilities)
- server-backed `nix develop --command bash -lc 'npm test'`
  - 9 Hugo checks
  - 20 functional tests
  - 100 accessibility checks, zero violations
- rendered Talks, Search, and search-index assertions
- `npm run test:links` (12/12 links successful)
- CI-equivalent `lychee` check (90/90 links successful)
- `npm run test:spell` (48 files, zero issues)
- complete changed-Markdown shell-fence syntax validation
- `git diff --check`
- staged `pre-commit run --all-files`

## Branch review

- Classification: non-code content and documentation plan
- Trail of Bits review skills: skipped because there are no code-relevant changes
- Manual differential review found no blocking issues and no follow-up ideas

## Post-PR verification

Reviewed published head: `fe9219f5613b71c54f2fe7b4780e6d6e7065ac4c`

| Criterion | Evidence | Result |
| --- | --- | --- |
| #388 Talks page review is current | Remote diff sets `reviewed: 2026-09-05` and adds the requested session | Passed |
| Published session details are faithful | Fresh Sessionize payload for session `1269187` matches the title, 19 October date, normalized abstract, and absent resources | Passed |
| #389 Search page review is current | Remote diff changes only the inert `reviewed` field in `content/search.md` | Passed |
| Search and Talks still render | Clean Nix-backed Hugo rerun passed 9/9 checks; rendered Talks, Search, and index assertions passed | Passed |
| PR scope and closing linkage are complete | Remote head changes exactly the three planned files and GitHub links both closing issues | Passed |

A direct post-PR `npm run test:hugo` invocation initially failed because Hugo was not on the plain shell's `PATH`; rerunning the same check in the repository's Nix environment passed 9/9. Both issues were re-fetched unchanged and without comments. No blocking or non-blocking findings were identified, and the reviewed head did not change.

## Hosted checks

- Required GitHub checks passed: `test (22.x)`, `lint`, `Conform`, `Spell Check with cspell`, and `Reject escaped newlines`
- Content-triggered `lighthouse` check passed
- Netlify deploy preview and header checks passed; page-change and redirect-rule checks skipped as configured

Closes #388
Closes #389
